### PR TITLE
#564 Remained NeuVector related reference after migrating the repo to Rancher org

### DIFF
--- a/.github/workflows/add_issue.yaml
+++ b/.github/workflows/add_issue.yaml
@@ -18,5 +18,5 @@ jobs:
           owner: ${{ github.repository_owner }}
       - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
-          project-url: https://github.com/orgs/neuvector/projects/10
+          project-url: https://github.com/orgs/rancher/projects/143
           github-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -17,13 +17,13 @@ jobs:
     - name: Checkout
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
-    # The FOSSA token is shared between all repos in NeuVector's GH org. It can
+    # The FOSSA token is shared between all repos in Rancher's GH org. It can
     # be used directly and there is no need to request specific access to EIO.
     - name: Read FOSSA token
       uses: rancher-eio/read-vault-secrets@7282bf97898cd1c16c89f837e0bb442e6d384c89 # v3
       with:
         secrets: |
-          secret/data/github/org/neuvector/fossa/credentials token | FOSSA_API_KEY_PUSH_ONLY
+          secret/data/github/org/rancher/fossa/credentials token | FOSSA_API_KEY_PUSH_ONLY
 
     - name: FOSSA scan
       uses: fossas/fossa-action@c414b9ad82eaad041e47a7cf62a4f02411f427a0 # v1.8.0

--- a/pkg/vulnerability-scanner/utils/chart.ts
+++ b/pkg/vulnerability-scanner/utils/chart.ts
@@ -56,13 +56,13 @@ export async function refreshCharts(
 
     if (!chart) {
       try {
-        // TODO: Add Custom VueX store for neuvector: { refreshingCharts: false }
-        // store.dispatch("neuvector/updateRefreshingCharts", true);
+        // TODO: Add Custom VueX store for rancher: { refreshingCharts: false }
+        // store.dispatch("rancher/updateRefreshingCharts", true);
         await store.dispatch('catalog/refresh');
       } catch (e) {
         handleGrowl({ error: e as any, store });
       } finally {
-        // store.dispatch("neuvector/updateRefreshingCharts", false);
+        // store.dispatch("rancher/updateRefreshingCharts", false);
       }
 
       if (retry < 2 && !init) {


### PR DESCRIPTION
Replace all the "neuvector" related statement into "rancher"
Change the project view URL into current rancher's