### PR TITLE
#556 [bugfix] adjust read-more vertical alignment

### DIFF
--- a/pkg/vulnerability-scanner/components/common/ExpandableDescription.vue
+++ b/pkg/vulnerability-scanner/components/common/ExpandableDescription.vue
@@ -103,7 +103,7 @@ export default {
 
 .read-more-btn {
   position: absolute;
-  bottom: 0;
+  bottom: 2px;
   right: 0;
   color: var(--disabled-text);
   text-decoration: underline;


### PR DESCRIPTION
Description
Fix #556 
fixes a bug in the ExpandableDescription component where the "... read more" suffix was vertically misaligned with the text when the description was truncated.

The fix:
Adjusted the .read-more-btn CSS

Test

Navigate to any page containing a long description using the ExpandableDescription component (e.g., the Vulnerability Details page).

The "... read more" suffix should now be vertically aligned with the truncated text

<img width="1515" height="318" alt="Screenshot 2026-05-07 at 6 12 24 PM" src="https://github.com/user-attachments/assets/34bdd2ea-9afe-4b5c-af7c-7964a4e099f3" />
