### PR TITLE
#571 [bugfix] default workloadScanConfiguration to disabled on creation

### DIFF
--- a/pkg/vulnerability-scanner/edit/__tests__/sbomscanner.kubewarden.io.workloadscanconfiguration.spec.ts
+++ b/pkg/vulnerability-scanner/edit/__tests__/sbomscanner.kubewarden.io.workloadscanconfiguration.spec.ts
@@ -140,7 +140,7 @@ describe('CruWorkloadScanConfiguration.vue', () => {
       wrapper = createWrapper({}, 'create', {}); // Completely empty object
       wrapper.vm.initDefaults();
       expect(wrapper.vm.value.metadata.name).toBe('default');
-      expect(wrapper.vm.value.spec.enabled).toBe(true);
+      expect(wrapper.vm.value.spec.enabled).toBe(false);
       expect(wrapper.vm.value.spec.platforms).toEqual([]);
       expect(wrapper.vm.value.spec.artifactsNamespace).toBe('cattle-sbomscanner-system');
     });

--- a/pkg/vulnerability-scanner/edit/sbomscanner.kubewarden.io.workloadscanconfiguration.vue
+++ b/pkg/vulnerability-scanner/edit/sbomscanner.kubewarden.io.workloadscanconfiguration.vue
@@ -177,7 +177,7 @@ export default {
       }
 
       const defaultSpec = {
-        enabled:            true,
+        enabled:            false,
         scanOnChange:       true,
         artifactsNamespace: this.vulnerabilityScannerInstallationNamespace,
         namespaceSelector:  {},


### PR DESCRIPTION
Description

Fix #571

This PR fixes a bug where the "Workloads Scan" configuration page defaulted to an "Enabled" state during initial creation. This was confusing because it implied scanning was active before a configuration resource even existed on the cluster.

<img width="1665" height="602" alt="Screenshot 2026-05-08 at 6 02 28 PM" src="https://github.com/user-attachments/assets/1fb63a99-cf46-45e1-80d6-38bdf800e023" />
