### PR TITLE
Add github-actions to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,10 @@ updates:
     ignore:                           # Ignore everything that is not a security update
       - dependency-name: "*"
         update-types: ["version-update:semver-patch", "version-update:semver-minor", "version-update:semver-major"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Add weekly job to bump github-actions.
Initial dependabot PRs might require manual intervention, some actions are quite old ([checkout@v2](https://github.com/rancher/security-ui-exts/blob/main/.github/workflows/unit-test.yml#L7C15-L7C31) for example).