### PR TITLE
#609: Registries Configuration summary section overflows on smaller screens

### DIFF
--- a/pkg/vulnerability-scanner/components/DistributionChart.vue
+++ b/pkg/vulnerability-scanner/components/DistributionChart.vue
@@ -60,7 +60,8 @@ export default {
         flex-direction: column;
         align-items: flex-start;
         gap: 12px;
-        flex: 1 0 0;
+        flex: 1 1 0;
+        overflow: hidden;
         .title {
             display: flex;
             align-items: center;

--- a/pkg/vulnerability-scanner/components/RecentUpdatedRegistries.vue
+++ b/pkg/vulnerability-scanner/components/RecentUpdatedRegistries.vue
@@ -31,30 +31,30 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-    .chart-section {
-        display: flex;
-        padding: 16px;
-        flex-direction: column;
-        align-items: flex-start;
-        min-width: 680px;
-        gap: 12px;
-        flex: 1 0 0;
-        border-right: solid var(--border-width) var(--input-border);
-        .title {
-            display: flex;
-            align-items: center;
-            gap: 8px;
-            font-family: Lato;
-            font-size: 18px;
-            font-style: normal;
-            font-weight: 400;
-            line-height: 21px; /* 116.667% */
-            margin-right: 8px;
-        }
-        .status-list {
-            padding: 4px 0;
-            align-items: center;
-            align-self: stretch;
-        }
+  .chart-section {
+    display: flex;
+    padding: 16px;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+    flex: 1 0 0;
+    max-width: 50%;
+    border-right: solid var(--border-width) var(--input-border);
+    .title {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-family: Lato;
+      font-size: 18px;
+      font-style: normal;
+      font-weight: 400;
+      line-height: 21px; /* 116.667% */
+      margin-right: 8px;
     }
+    .status-list {
+      padding: 4px 0;
+      align-items: center;
+      align-self: stretch;
+    }
+  }
 </style>

--- a/pkg/vulnerability-scanner/components/common/RegistryStatusUpdate.vue
+++ b/pkg/vulnerability-scanner/components/common/RegistryStatusUpdate.vue
@@ -80,75 +80,65 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-    .no-data {
-        color: var(--disabled-text);
-        font-family: Lato;
-        font-size: 14px;
-        font-style: normal;
-        font-weight: 400;
-        line-height: 21px;
-        min-height: 21px;
-        width: 100%;
+  .no-data {
+    color: var(--disabled-text);
+    font-family: Lato;
+    font-size: 14px;
+    font-style: normal;
+    font-weight: 400;
+    line-height: 21px;
+    min-height: 21px;
+    width: 100%;
+  }
+  .registry-status-record {
+    display: flex;
+    padding: 4px 0;
+    align-items: center;
+    align-self: stretch;
+    overflow: hidden;
+
+    .registry-name,
+    .uri {
+      padding: 0 16px;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
     }
-    .registry-status-record {
-        display: flex;
-        padding: 4px 12px;
-        align-items: center;
-        align-self: stretch;
-        .registry-name {
-            display: -webkit-box;
-            -webkit-box-orient: vertical;
-            -webkit-line-clamp: 1;
-            flex: 6;
-            overflow: hidden;
-            color: #5696CE;
-            text-overflow: ellipsis;
-            font-family: Lato;
-            font-size: 14px;
-            font-style: normal;
-            font-weight: 400;
-            line-height: 21px;
-        }
-        .uri {
-            display: -webkit-box;
-            -webkit-box-orient: vertical;
-            -webkit-line-clamp: 1;
-            flex: 10;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            word-break: break-all;
-            font-family: Lato;
-            font-size: 14px;
-            font-style: normal;
-            font-weight: 400;
-            line-height: 21px;
-            margin-right: 8px;
-        }
-        .prev-status {
-            flex: 5;
-        }
-        .arrow {
-            flex: 2;
-            width: 16px;
-            height: 16px;
-            // background: url('../../assets/img/right.svg') no-repeat center center;
-            // background-size: contain;
-        }
-        .curr-status {
-            flex: 5;
-        }
-        .update-time {
-            color: var(--disabled-text);
-            flex: 6;
-            margin-left: 8px;
-            font-family: Lato;
-            font-size: 14px;
-            font-style: normal;
-            font-weight: 400;
-            line-height: 21px;
-        }
-        &:hover {
-            background-color: var(--sortable-table-selected-bg);
-        }
+
+    .registry-name {
+      display: block; // RouterLink renders as <a> (inline by default)
+      flex: 1 0 0;
+      min-width: 64px;
     }
+
+    .uri {
+      flex: 1 0 200px;
+    }
+
+    .prev-status,
+    .arrow,
+    .curr-status {
+      display: flex;
+      flex-shrink: 0;
+      height: 24px;
+      padding: 0 4px;
+      align-items: center;
+    }
+
+    .prev-status,
+    .curr-status {
+      width: 85px;
+    }
+
+    .update-time {
+      color: var(--disabled-text);
+      width: 90px;
+      padding: 0 16px;
+      white-space: nowrap;
+    }
+
+    &:not(:has(.no-data)):hover {
+      background-color: var(--sortable-table-selected-bg);
+    }
+  }
 </style>

--- a/pkg/vulnerability-scanner/components/common/StatusBadge.vue
+++ b/pkg/vulnerability-scanner/components/common/StatusBadge.vue
@@ -114,6 +114,8 @@ export default {
       -webkit-box-orient: vertical;
       -webkit-line-clamp: 1;
       line-clamp: 1;
+      overflow: hidden;
+      white-space: nowrap;
       font-family: Lato;
       font-size: 12px;
       font-style: normal;

--- a/pkg/vulnerability-scanner/pages/c/_cluster/vulnerability-scanner/RegistriesConfiguration.vue
+++ b/pkg/vulnerability-scanner/pages/c/_cluster/vulnerability-scanner/RegistriesConfiguration.vue
@@ -203,8 +203,8 @@ export default {
         });
 
       });
-      // Sort and limit the registryStatusList to 5 most recent updates
-      registryStatusList.sort((a, b) => new Date(b.lastTransitionTime) - new Date(a.lastTransitionTime)).slice(0, 5);
+      // Sort the registryStatusList by most recent update
+      registryStatusList.sort((a, b) => new Date(b.lastTransitionTime) - new Date(a.lastTransitionTime));
       while (registryStatusList.length < 5) {
         registryStatusList.push({
           registryName:       '',

--- a/pkg/vulnerability-scanner/pages/c/_cluster/vulnerability-scanner/RegistriesConfiguration.vue
+++ b/pkg/vulnerability-scanner/pages/c/_cluster/vulnerability-scanner/RegistriesConfiguration.vue
@@ -384,7 +384,6 @@ export default {
 
   .summary-section {
     display: flex;
-    min-width: 1360px;
     align-items: flex-start;
     align-self: stretch;
     border-radius: 6px;


### PR DESCRIPTION
## Description

Fix #609 
Reworks status update row layout to match Figma design.
<img width="1512" height="757" alt="Screenshot 2026-06-17 at 4 34 51 PM" src="https://github.com/user-attachments/assets/ef858e67-413b-4cdb-aa72-db31c0ae0fc3" />


## Test

1. Open **Registries Configuration** with registries that have long names/URIs
2. At default viewport: verify both summary panels are 50% width, status rows show registry name, URI, badges, and update time without overflow (albeit possible truncation)
3. Shrink the viewport — verify content clips gracefully (rows truncate, panels don't bleed into each other)
4. Verify "In progress" and other badge text never wraps or truncates
5. Expand viewport — verify registry name and URI columns both grow proportionally