### PR TITLE
Adjust the height of buttons for the resource tables in the whole product

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@rancher/components": "^0.3.0-alpha.4",
-    "@rancher/shell": "3.0.12-rc.4",
+    "@rancher/shell": "3.0.12-rc.5",
     "file-saver": "^2.0.5",
     "papaparse": "^5.5.3",
     "vue": "^3.5.18",

--- a/pkg/runtime-enforcer/components/__tests__/InstallView.spec.ts
+++ b/pkg/runtime-enforcer/components/__tests__/InstallView.spec.ts
@@ -29,14 +29,6 @@ jest.mock('../../utils/chart', () => ({
   refreshCharts:    jest.fn(),
   getLatestVersion: jest.fn(() => '1.2.3'),
 }));
-jest.mock('@shell/config/types', () => ({
-  CATALOG: {
-    APP:          'catalog.cattle.io.app',
-    CLUSTER_REPO: 'catalog.cattle.io.clusterrepo',
-  },
-  SECRET:    'secret',
-  NAMESPACE: 'namespace',
-}));
 
 const InstallWizardStub = {
   name:     'InstallWizard',

--- a/pkg/vulnerability-scanner/components/common/ImageTableSet.vue
+++ b/pkg/vulnerability-scanner/components/common/ImageTableSet.vue
@@ -89,17 +89,16 @@
     >
       <template #header-left>
         <div class="table-top-left">
-          <button
-            mat-button
-            class="btn role-primary btn-text-report"
-            aria-label="Download custom report"
+          <RcButton
+            variant="primary"
+            size="medium"
+            :aria-label="isInWorkloadContext ? t('imageScanner.workloads.buttons.downloadReport') : t('imageScanner.images.buttons.downloadCustomReport')"
             :disabled="!(selectedRows && selectedRows.length)"
-            type="button"
             @click="downloadCSVReport(selectedRows, isGrouped)"
           >
-            <i class="icon icon-download me-3"></i>
+            <i class="icon icon-download"></i>
             {{ isInWorkloadContext ? t('imageScanner.workloads.buttons.downloadReport') : t('imageScanner.images.buttons.downloadCustomReport')}}
-          </button>
+          </RcButton>
           <span class="selected-count ms-4" v-if="selectedRows && selectedRows.length">
             {{ selectedRows.length }} {{ isGrouped ? t('typeLabel.repositorySelected', { count: selectedRows.length }, true) : t('typeLabel.imageSelected', { count: selectedRows.length }, true) }}
           </span>
@@ -149,6 +148,7 @@
 </template>
 
 <script>
+import { RcButton } from '@components/RcButton';
 import SortableTable from '@shell/components/SortableTable';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 import ActionMenu from '@shell/components/ActionMenuShell.vue';
@@ -182,6 +182,7 @@ export default {
     }
   },
   components: {
+    RcButton,
     LabeledSelect,
     SortableTable,
     Checkbox,
@@ -688,10 +689,6 @@ export default {
     gap: 8px;
     padding-top: 16px;
     border-top: 1px solid #DCDEE7;
-  }
-
-  .btn-text-report {
-    padding: 0 16px;
   }
 
   .me-3 {

--- a/pkg/vulnerability-scanner/components/common/ScanButton.vue
+++ b/pkg/vulnerability-scanner/components/common/ScanButton.vue
@@ -1,19 +1,23 @@
 <template>
-  <button
-    class="btn role-primary scan-btn"
+  <RcButton
+    variant="primary"
+    size="medium"
+    :aria-label="t('imageScanner.registries.button.startScan')"
     :disabled="disableBtn"
     @click="startScan()"
   >
     <i class="icon icon-play"></i>
     {{ t('imageScanner.registries.button.startScan') || 'Enable' }}
-  </button>
+  </RcButton>
 </template>
 
 <script>
+import { RcButton } from '@components/RcButton';
 import { RESOURCE } from '@vulnerability-scanner/types';
 
 export default {
-  name:  'ScanButton',
+  name:       'ScanButton',
+  components: { RcButton },
   props: {
     // Element object -> { name: string, namespace: string }
     selectedRegistries: {
@@ -64,11 +68,3 @@ export default {
   },
 };
 </script>
-
-<style scoped>
-.scan-btn {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-</style>

--- a/pkg/vulnerability-scanner/components/common/VulnerabilityTable.vue
+++ b/pkg/vulnerability-scanner/components/common/VulnerabilityTable.vue
@@ -18,14 +18,16 @@
     >
       <template #header-left>
         <div class="table-header-actions">
-          <button
-            class="btn role-primary btn-text-report"
+          <RcButton
+            variant="primary"
+            size="medium"
+            :aria-label="isInWorkloadContext ? t('imageScanner.workloads.buttons.downloadReport') : t('imageScanner.images.buttons.downloadCustomReport')"
             :disabled="selectedVulnerabilityCount === 0"
             @click="downloadCustomReport"
           >
-            <i class="icon icon-download me-3"></i>
+            <i class="icon icon-download"></i>
             {{ isInWorkloadContext ? t('imageScanner.workloads.buttons.downloadReport') : t('imageScanner.images.buttons.downloadCustomReport')}}
-          </button>
+          </RcButton>
           <span
             v-if="selectedVulnerabilityCount > 0"
             class="selected-count"
@@ -64,6 +66,7 @@
 </template>
 
 <script>
+import { RcButton } from '@components/RcButton';
 import { Checkbox } from '@components/Form/Checkbox';
 import {
   createCsvRows,
@@ -80,6 +83,7 @@ import day from 'dayjs';
 export default {
   name:       'VulnerabilityTable',
   components: {
+    RcButton,
     SortableTable,
     Checkbox,
   },
@@ -507,10 +511,6 @@ export default {
   display: flex;
   align-items: center;
   gap: 16px;
-}
-
-.btn-text-report {
-  padding: 0 16px;
 }
 
 .me-3 {

--- a/pkg/vulnerability-scanner/components/common/__tests__/ImageTableSet.spec.ts
+++ b/pkg/vulnerability-scanner/components/common/__tests__/ImageTableSet.spec.ts
@@ -69,6 +69,7 @@ const factory = (props = {}, storeOverrides = {}) => {
         Checkbox:      CheckboxStub,
         LabeledSelect: LabeledSelectStub,
         ActionMenu:    true,
+        RcButton:      { template: '<button><slot/></button>' },
       },
     },
   });

--- a/pkg/vulnerability-scanner/components/common/__tests__/ScanButton.spec.ts
+++ b/pkg/vulnerability-scanner/components/common/__tests__/ScanButton.spec.ts
@@ -48,7 +48,8 @@ describe('ScanButton.vue', () => {
         mocks: {
           $store: { dispatch: mockDispatch },
           t:      mockT
-        }
+        },
+        stubs: { RcButton: { template: '<button><slot/></button>' } }
       }
     });
   };

--- a/pkg/vulnerability-scanner/list/sbomscanner.kubewarden.io.registry.vue
+++ b/pkg/vulnerability-scanner/list/sbomscanner.kubewarden.io.registry.vue
@@ -79,21 +79,19 @@
         <div class="table-top-left">
           <ScanButton
             v-if="canEdit"
-            class="table-btn"
             :selected-registries="selectedRows?.map(row => {return {name: row.metadata.name, namespace: row.metadata.namespace, currStatus: row.currStatus}})"
           />
-          <button
+          <RcButton
             v-if="canDelete"
-            class="btn role-primary table-btn"
+            variant="primary"
+            size="medium"
+            :aria-label="t('imageScanner.registries.button.delete')"
             :disabled="!(selectedRows && selectedRows.length)"
             @click="promptRemoveRegistry()"
           >
-            <i
-              class="icon icon-delete"
-              style="margin-right: 8px;"
-            ></i>
+            <i class="icon icon-delete"></i>
             {{ t('imageScanner.registries.button.delete') || 'Delete' }}
-          </button>
+          </RcButton>
           <div
             v-if="selectedRows.length > 0"
             class="selected-count"
@@ -107,6 +105,7 @@
 
 <script>
 
+import { RcButton } from '@components/RcButton';
 import { RESOURCE } from '@vulnerability-scanner/types';
 import PaginatedResourceTable from '@shell/components/PaginatedResourceTable';
 import { REGISTRY_SCAN_TABLE } from '@vulnerability-scanner/config/table-headers';
@@ -121,6 +120,7 @@ import RegistriesOverview from '@vulnerability-scanner/pages/c/_cluster/vulnerab
 export default {
   name:       'Registries',
   components: {
+    RcButton,
     PaginatedResourceTable,
     LabeledSelect,
     ScanButton,
@@ -308,9 +308,6 @@ export default {
       justify-content: start;
       flex: 1 0 0;
       gap: 16px;
-    .table-btn {
-      height: 40px;
-    }
   }
 
   .selected-count {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2558,10 +2558,10 @@
   resolved "https://registry.yarnpkg.com/@rancher/icons/-/icons-2.0.55.tgz#394159bddbf786c17a12bc38e59b88346b30dcf4"
   integrity sha512-hPcmsvfYNO36dJ7/lb3JbJC5BOnHbwBylic7HRqhSCSIcFlFaKnRt9aB/hvv3ip0Wo6J5yVEv2o7oXGErXkWFw==
 
-"@rancher/shell@3.0.12-rc.4":
-  version "3.0.12-rc.4"
-  resolved "https://registry.yarnpkg.com/@rancher/shell/-/shell-3.0.12-rc.4.tgz#3defe4135cbf5ba254645b64081b5a0cb7dab6f8"
-  integrity sha512-3eo6jCJp29OvNfSkWRnYk8gfHPgFDntYIavWEgX5cLGelERuEl6D0nZTkEAWyoKqRfJ9tQpsI5mbuwV+z+gRRA==
+"@rancher/shell@3.0.12-rc.5":
+  version "3.0.12-rc.5"
+  resolved "https://registry.yarnpkg.com/@rancher/shell/-/shell-3.0.12-rc.5.tgz#971cce18c31955c7688a66cc7b47801987c19b46"
+  integrity sha512-Cu18lProlQOC5oiz2p17gSIlwybgkTrSjDcbXv/wlT5r2A7kEbzLWxBRtIvSgNlKeOYnNvf2WyM7cOKEYDl6bA==
   dependencies:
     "@aws-sdk/client-ec2" "3.1041.0"
     "@aws-sdk/client-eks" "3.1041.0"
@@ -13089,7 +13089,7 @@ string-length@^5.0.1:
     char-regex "^2.0.0"
     strip-ansi "^7.0.1"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -13105,6 +13105,15 @@ string-width@^2.1.1:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -13161,7 +13170,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -13174,6 +13183,13 @@ strip-ansi@^4.0.0:
   integrity sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==
   dependencies:
     ansi-regex "^3.0.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.2.0"
@@ -14433,7 +14449,7 @@ worker-loader@3.0.8:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -14454,6 +14470,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## Description

Fix #638 

## Test

1. Navigate to all Vulnerability Scanner pages that contain a `ResourceTable` (eg. **Vulnerability Scanner > Images**), including injected tabs (ie. **Workloads > Deployments > [deployment] > Vulnerabilities**) 
2. Verify that all table action buttons are `32px` and consistent with the rest of dashboard UX

## Additional Information


### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

Does not touch the sizing of column based filters. That fix is blocked pending rancher/dashboard#18296