### PR TITLE
Fix per-extension builds failing due to missing @common alias

### DIFF
--- a/pkg/runtime-enforcer/tsconfig.json
+++ b/pkg/runtime-enforcer/tsconfig.json
@@ -41,7 +41,8 @@
         "@rancher/components/*"
       ],
       "@tests/*": ["./tests/*"],
-      "@runtime-enforcer/*": ["./pkg/runtime-enforcer/*"]
+      "@runtime-enforcer/*": ["./*"],
+      "@common/*": ["../common/*"]
     }
   },
   "include": [

--- a/pkg/runtime-enforcer/tsconfig.json
+++ b/pkg/runtime-enforcer/tsconfig.json
@@ -15,6 +15,7 @@
     "preserveSymlinks": true,
     "typeRoots": [
       "../../node_modules",
+      "../../node_modules/@types",
       "../../node_modules/@rancher/shell/types"
     ],    
     "types": [

--- a/pkg/runtime-enforcer/vue.config.js
+++ b/pkg/runtime-enforcer/vue.config.js
@@ -14,6 +14,8 @@ module.exports = () => {
     }
     // Add the @runtime-enforcer alias to point to the pkg/runtime-enforcer directory.
     config.resolve.alias['@runtime-enforcer'] = path.resolve(__dirname);
+    // Add the @common alias so shared components in pkg/common are bundled with this extension.
+    config.resolve.alias['@common'] = path.resolve(__dirname, '../common');
   };
 
   // Create an override for __tests__ directories.

--- a/pkg/vulnerability-scanner/tsconfig.json
+++ b/pkg/vulnerability-scanner/tsconfig.json
@@ -44,6 +44,7 @@
       ],
       "@tests/*": ["./tests/*"],
       "@vulnerability-scanner/*": ["./*"],
+      "@common/*": ["../common/*"]
     }
   },
   "include": [

--- a/pkg/vulnerability-scanner/tsconfig.json
+++ b/pkg/vulnerability-scanner/tsconfig.json
@@ -16,8 +16,7 @@
     "typeRoots": [
       "../../node_modules",
       "../../node_modules/@types",
-      "../../node_modules/@rancher/shell/types",
-      "./types"
+      "../../node_modules/@rancher/shell/types"
     ],    
     "types": [
       "node",

--- a/pkg/vulnerability-scanner/vue.config.js
+++ b/pkg/vulnerability-scanner/vue.config.js
@@ -14,6 +14,8 @@ module.exports = () => {
     }
     // Add the @vulnerability-scanner alias to point to the pkg/vulnerability-scanner directory.
     config.resolve.alias['@vulnerability-scanner'] = path.resolve(__dirname);
+    // Add the @common alias so shared components in pkg/common are bundled with this extension.
+    config.resolve.alias['@common'] = path.resolve(__dirname, '../common');
   };
 
   // Create an override for __tests__ directories.


### PR DESCRIPTION
## Description

Production `build-pkg.sh` builds of `vulnerability-scanner` and `runtime-enforcer` fail with `Module not found: Can't resolve '@common/...'` because each pkg's own `vue.config.js` / `tsconfig.json` lacks a `@common` alias/path — so this PR adds one to each. Also fixed an unrelated pre-existing bug in `pkg/runtime-enforcer/tsconfig.json` breaking `@runtime-enforcer/*` imports during pkg builds.

## Test

```
yarn build-pkg vulnerability-scanner
yarn build-pkg runtime-enforcer
```
All `build-pkg` builds should complete with no `Module not found` errors.
Also verified via the `build-extension-charts.yml` release pipeline on a [personal fork](https://github.com/rushk014/security-ui-exts/actions/runs/29946448252/job/89013881397).


## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
