### PR TITLE
#634 Runtime Enforcer: Policy Proposals edit view

### DIFF
--- a/pkg/runtime-enforcer/edit/__tests__/security.rancher.io.workloadpolicyproposal.spec.ts
+++ b/pkg/runtime-enforcer/edit/__tests__/security.rancher.io.workloadpolicyproposal.spec.ts
@@ -1,0 +1,117 @@
+import { shallowMount } from '@vue/test-utils';
+import { createStore } from 'vuex';
+import WorkloadPolicyProposalEdit from '../security.rancher.io.workloadpolicyproposal.vue';
+
+describe('WorkloadPolicyProposalEdit component', () => {
+  let store: any;
+
+  beforeEach(() => {
+    store = createStore({
+      getters: {
+        'i18n/t':            () => (key: string) => key,
+        'i18n/exists':       () => () => true,
+        'cluster/schemaFor': () => () => ({ canCreate: true }),
+      },
+    });
+    store.dispatch = jest.fn().mockResolvedValue({});
+  });
+
+  it('renders the edit form components successfully', () => {
+    const wrapper = shallowMount(WorkloadPolicyProposalEdit, {
+      global: {
+        plugins: [store],
+        stubs:   {
+          CruResource:       true,
+          NameNsDescription: true,
+          LabeledInput:      true,
+          Tabbed:            true,
+          Tab:               true,
+          Banner:            true,
+        },
+      },
+      props: {
+        mode:  'edit',
+        value: {
+          metadata: { name: 'test-proposal', namespace: 'default' },
+          spec:     {
+            rulesByContainer: {
+              'my-container': {
+                executables: { allowed: ['/usr/bin/bash'] }
+              }
+            }
+          }
+        }
+      }
+    });
+
+    expect(wrapper.exists()).toBe(true);
+    expect(wrapper.vm.workloadName).toBe('');
+  });
+
+  it('validates form and catches empty or invalid executable paths', () => {
+    const wrapper = shallowMount(WorkloadPolicyProposalEdit, {
+      global: {
+        plugins: [store],
+        stubs:   {
+          CruResource:       true,
+          NameNsDescription: true,
+          LabeledInput:      true,
+          Tabbed:            true,
+          Tab:               true,
+          Banner:            true,
+        },
+      },
+      props: {
+        mode:  'edit',
+        value: {
+          metadata: { name: 'test-proposal', namespace: 'default' },
+          spec:     {
+            rulesByContainer: {
+              'audit-scanner': {
+                executables: { allowed: [''] }
+              }
+            }
+          }
+        }
+      }
+    });
+
+    const errors = wrapper.vm.validateForm();
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('successfully adds a new executable path entry', () => {
+    const wrapper = shallowMount(WorkloadPolicyProposalEdit, {
+      global: {
+        plugins: [store],
+        stubs:   {
+          CruResource:       true,
+          NameNsDescription: true,
+          LabeledInput:      true,
+          Tabbed:            true,
+          Tab:               true,
+          Banner:            true,
+        },
+      },
+      props: {
+        mode:  'edit',
+        value: {
+          metadata: { name: 'test-proposal', namespace: 'default' },
+          spec:     {
+            rulesByContainer: {
+              'audit-scanner': {
+                executables: { allowed: ['/usr/bin/bash'] }
+              }
+            }
+          }
+        }
+      }
+    });
+
+    wrapper.vm.addExecutable('audit-scanner');
+    const allowed = wrapper.vm.value.spec.rulesByContainer['audit-scanner'].executables.allowed;
+
+    expect(allowed).toContain('');
+    expect(allowed.length).toBe(2);
+  });
+});

--- a/pkg/runtime-enforcer/edit/security.rancher.io.workloadpolicyproposal.vue
+++ b/pkg/runtime-enforcer/edit/security.rancher.io.workloadpolicyproposal.vue
@@ -1,0 +1,436 @@
+<template>
+  <CruResource
+      :mode="mode"
+      :resource="value"
+      :errors="errors"
+      :validation-passed="isValid"
+      @finish="saveProposal"
+      @cancel="cancel"
+  >
+    <div class="policy-proposal-edit">
+
+      <Banner
+          v-for="(err, idx) in errors"
+          :key="idx"
+          color="error"
+          :label="err"
+      />
+
+      <NameNsDescription
+          :value="value"
+          :mode="mode"
+          name-label="runtimeEnforcer.policyProposal.policyName"
+      />
+
+      <div class="row mb-20">
+        <div class="col span-3">
+          <LabeledInput
+              :value="workloadName"
+              :label="t('runtimeEnforcer.policyProposal.masthead.workload')"
+              :mode="mode"
+              :disabled="true"
+              :required="true"
+          />
+        </div>
+        <div class="col span-3">
+          <LabeledInput
+              :value="workloadType"
+              :label="t('runtimeEnforcer.policyProposal.masthead.workloadType')"
+              :mode="mode"
+              :disabled="true"
+              :required="true"
+          />
+        </div>
+      </div>
+
+      <div class="containers-section mt-30">
+        <div class="containers-title-row mb-15">
+          <h3 class="m-0">
+            {{ t('runtimeEnforcer.policyProposal.containers.title') }}
+          </h3>
+        </div>
+
+        <div class="row">
+          <div class="col span-12">
+            <Tabbed :side-tabs="true">
+              <Tab
+                  v-for="(c, cIdx) in containerList"
+                  :key="c.name || cIdx"
+                  :name="c.name"
+                  :label="`${c.name} (${c.executables.length})`"
+                  :show-header="false"
+              >
+                <div class="container-content custom-content-bg p-20">
+                  <div class="row mb-20">
+                    <div class="col span-6">
+                      <LabeledInput
+                          :value="c.name"
+                          :label="t('runtimeEnforcer.policyProposal.containerName')"
+                          :mode="mode"
+                          :disabled="true"
+                          :required="true"
+                      />
+                    </div>
+
+                    <div class="col span-6">
+                      <LabeledInput
+                          :value="c.image"
+                          :label="t('runtimeEnforcer.policyProposal.containers.table.image')"
+                          :mode="mode"
+                          :disabled="true"
+                          :required="true"
+                      />
+                    </div>
+                  </div>
+
+                  <div class="executables-header mb-10 d-flex align-center">
+                    <label class="text-bold m-0">
+                      {{ t('runtimeEnforcer.policyProposal.allowedExecutables') }}
+                    </label>
+                    <i class="icon icon-info ml-5 text-muted" />
+                  </div>
+
+                  <!-- Executables Rows -->
+                  <div
+                      v-for="(exec, eIdx) in c.executables"
+                      :key="eIdx"
+                      class="executable-row row mb-10"
+                  >
+
+                    <div class="col span-6 input-with-badge">
+                      <div class="input-container">
+                        <LabeledInput
+                            :value="exec.path"
+                            :placeholder="t('runtimeEnforcer.policyProposal.executablePlaceholder')"
+                            :mode="mode"
+                            @update:value="updateExecutablePath(c.name, eIdx, $event)"
+                        />
+                      </div>
+                      <div class="badge-wrapper">
+                        <span
+                            class="type-badge text-center"
+                            :class="exec.source === EXEC_SOURCE.LEARNED ? 'badge-learned' : 'badge-manual'"
+                        >
+                          {{ exec.source === EXEC_SOURCE.LEARNED ? t('runtimeEnforcer.policyProposal.badges.learned') : t('runtimeEnforcer.policyProposal.badges.manualEntry') }}
+                        </span>
+                      </div>
+                    </div>
+
+                    <div class="col span-6 align-vertical-center">
+                      <a
+                          class="text-error cursor-pointer"
+                          @click="removeExecutable(c.name, eIdx)"
+                      >
+                        {{ t('generic.remove') }}
+                      </a>
+                    </div>
+                  </div>
+
+                  <div class="row mt-10">
+                    <div class="col span-6">
+                      <a
+                          class="text-primary cursor-pointer text-bold"
+                          @click="addExecutable(c.name)"
+                      >
+                        {{ t('runtimeEnforcer.policyProposal.addExecutable') }}
+                      </a>
+                    </div>
+                  </div>
+                </div>
+              </Tab>
+            </Tabbed>
+          </div>
+        </div>
+      </div>
+    </div>
+  </CruResource>
+</template>
+
+<script>
+import CruResource from '@shell/components/CruResource';
+import { LabeledInput } from '@components/Form/LabeledInput';
+import NameNsDescription from '@shell/components/form/NameNsDescription';
+import Tabbed from '@shell/components/Tabbed';
+import Tab from '@shell/components/Tabbed/Tab';
+import CreateEditView from '@shell/mixins/create-edit-view';
+import { EXEC_SOURCE } from '@runtime-enforcer/types/runtime-enforcer';
+import Banner from '@components/Banner/Banner';
+
+export default {
+  name: 'WorkloadPolicyProposalEdit',
+
+  components: {
+    CruResource,
+    LabeledInput,
+    NameNsDescription,
+    Tabbed,
+    Tab,
+    Banner
+  },
+
+  mixins: [CreateEditView],
+
+  props: {
+    value: {
+      type:     Object,
+      required: true
+    },
+    mode: {
+      type:     String,
+      required: true
+    }
+  },
+
+  data() {
+    return {
+      errors:                   [],
+      ownerWorkload:            null,
+      manualEntriesByContainer: {},
+      EXEC_SOURCE
+    };
+  },
+
+  async fetch() {
+    if (!this.value.ownerWorkloadSteveType || !this.value.workload) {
+      return;
+    }
+
+    try {
+      this.ownerWorkload = await this.$store.dispatch('cluster/find', {
+        type: this.value.ownerWorkloadSteveType,
+        id:   `${ this.value.metadata.namespace }/${ this.value.workload }`,
+      });
+    } catch (err) {
+      await this.$store.dispatch('growl/fromError', { err }, { root: true });
+    }
+  },
+
+  computed: {
+    spec() {
+      if (!this.value.spec) {
+        this.value.spec = {};
+      }
+
+      return this.value.spec;
+    },
+
+    ownerRef() {
+      return this.value.metadata?.ownerReferences?.[0] || {};
+    },
+
+    workloadName() {
+      return this.ownerRef.name || this.spec.workload || '';
+    },
+
+    workloadType() {
+      return this.ownerRef.kind || this.spec.workloadType || '';
+    },
+
+    containerImages() {
+      const containers = this.ownerWorkload?.spec?.template?.spec?.containers
+          || this.ownerWorkload?.spec?.jobTemplate?.spec?.template?.spec?.containers
+          || [];
+
+      return containers.reduce((acc, container) => {
+        acc[container.name] = container.image;
+
+        return acc;
+      }, {});
+    },
+
+    containerList() {
+      const rules = this.spec.rulesByContainer || {};
+
+      return Object.keys(rules).map((containerName) => {
+        const containerRules = rules[containerName] || {};
+        const allowed = containerRules.executables?.allowed || [];
+        const manualSet = this.manualEntriesByContainer[containerName] || new Set();
+
+        return {
+          name:        containerName,
+          image:       this.containerImages[containerName] || this.t('generic.none'),
+          executables: allowed.map((path) => ({
+            path,
+            source: manualSet.has(path) ? EXEC_SOURCE.MANUAL : EXEC_SOURCE.LEARNED
+          }))
+        };
+      });
+    },
+
+    isValid() {
+      return !!this.value?.metadata?.name;
+    }
+  },
+
+  methods: {
+    ensureRulesPath(containerName) {
+      if (!this.value.spec) {
+        this.value.spec = {};
+      }
+      if (!this.value.spec.rulesByContainer) {
+        this.value.spec.rulesByContainer = {};
+      }
+      if (!this.value.spec.rulesByContainer[containerName]) {
+        this.value.spec.rulesByContainer[containerName] = {};
+      }
+      if (!this.value.spec.rulesByContainer[containerName].executables) {
+        this.value.spec.rulesByContainer[containerName].executables = {};
+      }
+      if (!this.value.spec.rulesByContainer[containerName].executables.allowed) {
+        this.value.spec.rulesByContainer[containerName].executables.allowed = [];
+      }
+
+      return this.value.spec.rulesByContainer[containerName].executables.allowed;
+    },
+
+    addExecutable(containerName) {
+      const allowed = this.ensureRulesPath(containerName);
+
+      allowed.push('');
+
+      if (!this.manualEntriesByContainer[containerName]) {
+        this.manualEntriesByContainer[containerName] = new Set();
+      }
+      this.manualEntriesByContainer[containerName].add('');
+    },
+
+    updateExecutablePath(containerName, execIndex, val) {
+      const allowed = this.ensureRulesPath(containerName);
+      const oldVal = allowed[execIndex];
+
+      allowed.splice(execIndex, 1, val);
+
+      if (this.manualEntriesByContainer[containerName]) {
+        this.manualEntriesByContainer[containerName].delete(oldVal);
+        this.manualEntriesByContainer[containerName].add(val);
+      }
+    },
+
+    removeExecutable(containerName, execIndex) {
+      const allowed = this.ensureRulesPath(containerName);
+
+      allowed.splice(execIndex, 1);
+    },
+
+    validateForm() {
+      const errors = [];
+      const rules = this.spec.rulesByContainer || {};
+
+      Object.keys(rules).forEach((containerName) => {
+        const allowed = rules[containerName]?.executables?.allowed || [];
+
+        // Clean up empty strings or validate paths
+        for (let i = 0; i < allowed.length; i++) {
+          const path = (allowed[i] || '').trim();
+
+          if (!path) {
+            errors.push(this.t('runtimeEnforcer.policyProposal.errors.emptyPath', { container: containerName, index: i + 1 }));
+          } else if (!path.startsWith('/')) {
+            errors.push(this.t('runtimeEnforcer.policyProposal.errors.invalidPath', { path, container: containerName }));
+          }
+        }
+      });
+
+      return errors;
+    },
+
+    async saveProposal(buttonDone) {
+      this.errors = [];
+      const rules = this.spec.rulesByContainer || {};
+
+      Object.keys(rules).forEach((containerName) => {
+        if (rules[containerName]?.executables?.allowed) {
+          rules[containerName].executables.allowed = rules[containerName].executables.allowed
+            .map((p) => p.trim())
+            .filter(Boolean);
+        }
+      });
+
+      const validationErrors = this.validateForm();
+
+      if (validationErrors.length) {
+        this.errors = validationErrors;
+        buttonDone(false);
+
+        return;
+      }
+
+      try {
+        await this.value.save();
+        buttonDone(true);
+        this.done();
+      } catch (err) {
+        const apiError = err?.message || err?._statusText || err;
+
+        this.errors = [apiError];
+        buttonDone(false);
+      }
+    },
+
+    cancel() {
+      this.done();
+    }
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+.policy-proposal-edit {
+  .custom-content-bg {
+    background-color: var(--nav-bg, #f4f5f8);
+    border: 1px solid var(--border);
+    border-radius: var(--border-radius);
+  }
+
+  .executable-row {
+    display: flex;
+    align-items: center;
+    width: 100%;
+  }
+
+  .input-with-badge {
+    display: flex !important;
+    align-items: center !important;
+    flex-direction: row !important;
+
+    .input-container {
+      flex: 1 1 auto;
+      min-width: 0;
+
+      ::v-deep .labeled-input {
+        width: 100%;
+      }
+    }
+
+    .badge-wrapper {
+      width: 110px;
+      flex-shrink: 0;
+      margin-left: 10px;
+    }
+  }
+
+  .type-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 38px;
+    padding: 0 14px;
+    border-radius: 4px;
+    font-size: 12px;
+    background-color: var(--disabled-bg, #e2e6ec);
+    color: var(--text, #333);
+    white-space: nowrap;
+  }
+
+  .align-vertical-center {
+    display: flex;
+    align-items: center;
+    height: 54px;
+  }
+
+  .cursor-pointer {
+    cursor: pointer;
+  }
+}
+</style>

--- a/pkg/runtime-enforcer/edit/security.rancher.io.workloadpolicyproposal.vue
+++ b/pkg/runtime-enforcer/edit/security.rancher.io.workloadpolicyproposal.vue
@@ -4,6 +4,7 @@
       :resource="value"
       :errors="errors"
       :validation-passed="isValid"
+      :can-yaml="false"
       @finish="saveProposal"
       @cancel="cancel"
   >
@@ -118,7 +119,7 @@
 
                     <div class="col span-6 align-vertical-center">
                       <a
-                          class="text-error cursor-pointer"
+                          class="text-link cursor-pointer"
                           @click="removeExecutable(c.name, eIdx)"
                       >
                         {{ t('generic.remove') }}
@@ -376,6 +377,11 @@ export default {
 
 <style lang="scss" scoped>
 .policy-proposal-edit {
+  // Hide the auto-generated status badge next to the title in CruResource
+  :deep(.badge-state) {
+    display: none !important;
+  }
+
   .custom-content-bg {
     background-color: var(--nav-bg, #f4f5f8);
     border: 1px solid var(--border);

--- a/pkg/runtime-enforcer/l10n/en-us.yaml
+++ b/pkg/runtime-enforcer/l10n/en-us.yaml
@@ -91,11 +91,21 @@ runtimeEnforcer:
       continue: Continue
   policyProposal:
     label: Policy Proposal
+    policyName: Policy Name
+    description: Description
+    descriptionPlaceholder: Any text you want that better describes this configuration
+    containerName: Container Name
+    allowedExecutables: Allowed Executables
+    executablePlaceholder: /usr/bin/executable
+    addExecutable: Add Executable
     action:
       editPolicy: Edit Policy
       export: Export
       delete: Delete
       promote: Promote
+    badges:
+      learned: Learned
+      manualEntry: Manual Entry
     masthead:
       namespace: Namespace
       workload: Workload
@@ -138,3 +148,6 @@ runtimeEnforcer:
       delete:
         single: Delete Proposal and Restart Workload
         bulk: Delete Proposals and Restart Workloads
+    errors:
+      emptyPath: "Container {container}: Executable path at position {index} cannot be empty."
+      invalidPath: "Container {container}: Executable path {path} must start with a leading slash /."

--- a/pkg/runtime-enforcer/models/__tests__/security.rancher.io.workloadpolicyproposal.spec.ts
+++ b/pkg/runtime-enforcer/models/__tests__/security.rancher.io.workloadpolicyproposal.spec.ts
@@ -214,12 +214,14 @@ describe('WorkloadPolicyProposal model', () => {
 
   describe('editPolicy / exportPolicy / promote', () => {
     it('editPolicy() does not throw', () => {
+      proposal.detailLocation = { query: {} };
+      proposal.currentRouter = () => ({ push: jest.fn() });
+
       expect(() => proposal.editPolicy()).not.toThrow();
     });
 
     it('exportPolicy() dispatches promptModal with itself as the sole resource by default', () => {
       proposal.exportPolicy();
-
       expect(proposal.$dispatch).toHaveBeenCalledWith('promptModal', {
         component:  'ExportPolicyDialog',
         resources:  [proposal],
@@ -229,9 +231,7 @@ describe('WorkloadPolicyProposal model', () => {
 
     it('exportPolicy() dispatches promptModal with the given array of resources when called in bulk', () => {
       const other = new WorkloadPolicyProposal();
-
       proposal.exportPolicy([proposal, other]);
-
       expect(proposal.$dispatch).toHaveBeenCalledWith('promptModal', {
         component:  'ExportPolicyDialog',
         resources:  [proposal, other],
@@ -240,7 +240,10 @@ describe('WorkloadPolicyProposal model', () => {
     });
 
     it('promote() does not throw', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
       expect(() => proposal.promote()).not.toThrow();
+      warnSpy.mockRestore();
     });
   });
 

--- a/pkg/runtime-enforcer/models/security.rancher.io.workloadpolicyproposal.js
+++ b/pkg/runtime-enforcer/models/security.rancher.io.workloadpolicyproposal.js
@@ -139,8 +139,14 @@ export default class WorkloadPolicyProposal extends SteveModel {
   }
 
   editPolicy() {
-    // eslint-disable-next-line no-console
-    console.warn('WorkloadPolicyProposal.editPolicy() is not yet implemented.');
+    const location = this.detailLocation;
+
+    location.query = {
+      ...location.query,
+      mode: 'edit'
+    };
+
+    this.currentRouter().push(location);
   }
 
   exportPolicy(resources = this) {

--- a/pkg/runtime-enforcer/types/runtime-enforcer.ts
+++ b/pkg/runtime-enforcer/types/runtime-enforcer.ts
@@ -8,6 +8,18 @@ export const RESOURCE = {
   ACTIVE_POLICIES:  'security.rancher.io.workloadpolicy',
 };
 
+export const EXEC_SOURCE = {
+  LEARNED: 'learned',
+  MANUAL:  'manual',
+} as const;
+
+export type ExecSource = typeof EXEC_SOURCE[keyof typeof EXEC_SOURCE];
+
+export interface ExecutableItem {
+  path: string;
+  source: ExecSource;
+}
+
 export const WORKLOAD_POLICY_KIND = 'WorkloadPolicy';
 
 export const POLICY_MODE = {


### PR DESCRIPTION
## Description

Fix #634 

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

work with the backend team to introduce persistent source metadata into the WorkloadPolicyProposal CRD schema so that "learned" and "manual entry" status can be persisted.

<img width="1912" height="950" alt="Screenshot 2026-07-27 at 2 17 40 AM" src="https://github.com/user-attachments/assets/0c806e2d-628c-4ef1-929c-701fcb711f56" />

