### PR TITLE
Policy Proposal Promotion modal

### DIFF
--- a/pkg/runtime-enforcer/dialog/ChangeModeDialog.vue
+++ b/pkg/runtime-enforcer/dialog/ChangeModeDialog.vue
@@ -192,7 +192,6 @@ export default {
 <style lang="scss" scoped>
 .export-policy-dialog-card {
   box-shadow: none;
-  border-radius: var(--border-radius);
 
   :deep(.card-actions) {
     justify-content: end;
@@ -225,7 +224,6 @@ export default {
   .mode-text {
     overflow: hidden;
     text-overflow: ellipsis;
-    font-family: Lato;
     font-size: 14px;
     font-style: normal;
     font-weight: 500;

--- a/pkg/runtime-enforcer/dialog/DeleteActivePoliciesDialog.vue
+++ b/pkg/runtime-enforcer/dialog/DeleteActivePoliciesDialog.vue
@@ -244,7 +244,6 @@ export default {
 <style lang="scss" scoped>
 .delete-policy-proposals-dialog-card {
   box-shadow: none;
-  border-radius: var(--border-radius);
 
   :deep(.card-actions) {
     justify-content: end;
@@ -295,7 +294,6 @@ export default {
     white-space: nowrap;
     max-width: calc(100%);
     line-height: 21px;
-    font-family: Lato;
     font-size: 13px;
     font-weight: 400;
     align-items: center;

--- a/pkg/runtime-enforcer/dialog/DeleteActivePoliciesDialog.vue
+++ b/pkg/runtime-enforcer/dialog/DeleteActivePoliciesDialog.vue
@@ -102,6 +102,11 @@ export default {
           : `${this.t('runtimeEnforcer.activePolicies.deleteDialog.growl.delete.single', { name: this.resources[0]?.nameDisplay })} ${this.t('runtimeEnforcer.activePolicies.deleteDialog.growl.manualRemoval.single')}`;
       }
     },
+    growlTitle() {
+      return this.isBulk
+        ? this.t('runtimeEnforcer.activePolicies.deleteDialog.growl.title.bulk', { count: this.resources.length }, true)
+        : this.t('runtimeEnforcer.activePolicies.deleteDialog.growl.title.single', { name: this.resources[0]?.nameDisplay }, true);
+    },
   },
 
   methods: {
@@ -141,7 +146,7 @@ export default {
       }));
 
       this.deleteInProgress = false;
-      this.$store.dispatch('growl/success', { message: this.growlMessage });
+      this.$store.dispatch('growl/success', { title: this.growlTitle, message: this.growlMessage });
       this.$router.push({
         name:   `c-cluster-${ PRODUCT_NAME }-resource`,
         params: {

--- a/pkg/runtime-enforcer/dialog/DeletePolicyProposalsDialog.vue
+++ b/pkg/runtime-enforcer/dialog/DeletePolicyProposalsDialog.vue
@@ -163,7 +163,6 @@ export default {
 <style lang="scss" scoped>
 .delete-policy-proposals-dialog-card {
   box-shadow: none;
-  border-radius: var(--border-radius);
 
   :deep(.card-actions) {
     justify-content: end;

--- a/pkg/runtime-enforcer/dialog/DeletePolicyProposalsDialog.vue
+++ b/pkg/runtime-enforcer/dialog/DeletePolicyProposalsDialog.vue
@@ -58,6 +58,12 @@ export default {
         ? this.t('runtimeEnforcer.policyProposal.deleteDialog.growl.bulk', { count: this.resources.length })
         : this.t('runtimeEnforcer.policyProposal.deleteDialog.growl.single');
     },
+
+    growlTitle() {
+      return this.isBulk
+        ? this.t('runtimeEnforcer.policyProposal.deleteDialog.growl.title.bulk', { count: this.resources.length }, true)
+        : this.t('runtimeEnforcer.policyProposal.deleteDialog.growl.title.single', { name: this.resources[0]?.nameDisplay }, true);
+    },
   },
 
   methods: {
@@ -95,7 +101,7 @@ export default {
 
       this.deleteInProgress = false;
 
-      this.$store.dispatch('growl/success', { message: this.growlMessage });
+      this.$store.dispatch('growl/success', { title: this.growlTitle, message: this.growlMessage });
 
       this.$router.push({
         name:   `c-cluster-${ PRODUCT_NAME }-resource`,

--- a/pkg/runtime-enforcer/dialog/ExportPolicyDialog.vue
+++ b/pkg/runtime-enforcer/dialog/ExportPolicyDialog.vue
@@ -140,7 +140,6 @@ export default {
 <style lang="scss" scoped>
 .export-policy-dialog-card {
   box-shadow: none;
-  border-radius: var(--border-radius);
 
   :deep(.card-actions) {
     justify-content: end;

--- a/pkg/runtime-enforcer/dialog/PromotePolicyDialog.vue
+++ b/pkg/runtime-enforcer/dialog/PromotePolicyDialog.vue
@@ -1,0 +1,365 @@
+<script>
+import { Card } from '@components/Card';
+import { Banner } from '@components/Banner';
+import RcButton from '@components/RcButton/RcButton.vue';
+import LabeledSelect from '@shell/components/form/LabeledSelect';
+import RadioButton from '@components/Form/Radio/RadioButton.vue';
+import RcTag from '@components/Pill/RcTag/RcTag.vue';
+import CopyToClipboard from '@shell/components/Resource/Detail/CopyToClipboard.vue';
+import RichTranslation from '@shell/components/RichTranslation.vue';
+import SubtleLink from '@shell/components/SubtleLink.vue';
+import { _EDIT } from '@shell/config/query-params';
+import {
+  PRODUCT_NAME, POLICY_MODE, APPLY_MODE, WORKLOAD_PREFIX, DOCUMENTATION_URL
+} from '../types/runtime-enforcer';
+import { applyPromoteLabel, snapshotProposal, runPromoteFollowUps } from '../utils/promote';
+
+export default {
+  emits: ['close'],
+
+  components: {
+    Card,
+    Banner,
+    RcButton,
+    LabeledSelect,
+    RadioButton,
+    RcTag,
+    CopyToClipboard,
+    RichTranslation,
+    SubtleLink,
+  },
+
+  props: {
+    resources: {
+      type:    Array,
+      default: () => [],
+    },
+  },
+
+  data() {
+    return {
+      step:              1,
+      targetMode:        POLICY_MODE.MONITOR,
+      applyOption:       APPLY_MODE.AUTOMATIC,
+      promoteInProgress: false,
+      _EDIT,
+      APPLY_MODE,
+      WORKLOAD_PREFIX,
+      DOCUMENTATION_URL,
+    };
+  },
+
+  computed: {
+    isBulk() {
+      return this.resources.length > 1;
+    },
+
+    title() {
+      const key = this.step === 1 ? 'title' : 'applyStep.title';
+
+      return this.t(`runtimeEnforcer.policyProposal.promoteDialog.${ key }.${ this.isBulk ? 'bulk' : 'single' }`);
+    },
+
+    bannerText() {
+      const key = this.step === 1 ? 'banner' : 'applyStep.banner';
+
+      return this.t(`runtimeEnforcer.policyProposal.promoteDialog.${ key }.${ this.isBulk ? 'bulk' : 'single' }`, { name: this.resources[0]?.workload }, true);
+    },
+
+    confirmText() {
+      return this.isBulk
+        ? this.t('runtimeEnforcer.policyProposal.promoteDialog.confirm.bulk', { count: this.resources.length }, true)
+        : this.t('runtimeEnforcer.policyProposal.promoteDialog.confirm.single', { name: this.resources[0]?.nameDisplay }, true);
+    },
+
+    modeOptions() {
+      return [
+        { value: POLICY_MODE.MONITOR, label: this.t('runtimeEnforcer.policyProposal.promoteDialog.mode.monitor') },
+        { value: POLICY_MODE.PROTECT, label: this.t('runtimeEnforcer.policyProposal.promoteDialog.mode.protect') },
+      ];
+    },
+
+    automaticOptionLabel() {
+      return this.t(`runtimeEnforcer.policyProposal.promoteDialog.applyStep.options.automatic.${ this.isBulk ? 'bulk' : 'single' }`);
+    },
+
+    manualOptionLabel() {
+      return this.t(`runtimeEnforcer.policyProposal.promoteDialog.applyStep.options.manual.${ this.isBulk ? 'bulk' : 'single' }`);
+    },
+
+    manualDescriptionKey() {
+      return `runtimeEnforcer.policyProposal.promoteDialog.applyStep.manualDescription.${ this.isBulk ? 'bulk' : 'single' }`;
+    },
+
+    growlTitle() {
+      return this.isBulk
+        ? this.t('runtimeEnforcer.policyProposal.promoteDialog.growl.title.bulk', { count: this.resources.length }, true)
+        : this.t('runtimeEnforcer.policyProposal.promoteDialog.growl.title.single', { name: this.resources[0]?.nameDisplay }, true);
+    },
+
+    growlMessage() {
+      const base = this.isBulk
+        ? this.t('runtimeEnforcer.policyProposal.promoteDialog.growl.base.bulk', { count: this.resources.length }, true)
+        : this.t('runtimeEnforcer.policyProposal.promoteDialog.growl.base.single', {}, true);
+
+      const suffixKey = this.applyOption === APPLY_MODE.AUTOMATIC ? 'automatic' : 'manual';
+      const suffix = this.t(`runtimeEnforcer.policyProposal.promoteDialog.growl.${ suffixKey }.${ this.isBulk ? 'bulk' : 'single' }`, {}, true);
+
+      return `${ base } ${ suffix }`;
+    },
+  },
+
+  methods: {
+    close() {
+      this.$emit('close');
+    },
+
+    continueToApplyStep() {
+      this.step = 2;
+    },
+
+    async finish() {
+      this.promoteInProgress = true;
+
+      try {
+        await Promise.all(this.resources.map((resource) => applyPromoteLabel(resource)));
+      } catch (err) {
+        this.promoteInProgress = false;
+        this.$store.dispatch('growl/fromError', { title: this.t('runtimeEnforcer.policyProposal.promoteDialog.errorTitle'), err });
+
+        return;
+      }
+
+      const autoApply = this.applyOption === APPLY_MODE.AUTOMATIC;
+
+      this.resources.forEach((resource) => {
+        runPromoteFollowUps(this.$store, snapshotProposal(resource), {
+          targetMode: this.targetMode,
+          autoApply,
+        });
+      });
+
+      this.$store.dispatch('growl/success', { title: this.growlTitle, message: this.growlMessage });
+
+      if (!this.isBulk) {
+        this.$router.push({
+          name:   `c-cluster-${ PRODUCT_NAME }-resource`,
+          params: { cluster: this.$route.params.cluster, product: PRODUCT_NAME },
+        });
+      }
+
+      this.promoteInProgress = false;
+      this.close();
+    },
+  },
+};
+</script>
+
+<template>
+  <Card
+    class="promote-policy-dialog-card"
+    :show-highlight-border="false"
+  >
+    <template #title>
+      <h4 class="text-default-text">
+        {{ title }}
+      </h4>
+    </template>
+    <template #body>
+      <Banner
+        class="banner"
+        :color="step === 1 ? 'info' : 'warning'"
+      >
+        <span v-clean-html="bannerText" />
+      </Banner>
+
+      <template v-if="step === 1">
+        <p
+          class="confirm-text"
+          v-clean-html="confirmText"
+        />
+        <LabeledSelect
+          class="mode-select"
+          v-model:value="targetMode"
+          :options="modeOptions"
+        />
+      </template>
+
+      <template v-else>
+        <div
+          class="apply-option-group"
+          role="radiogroup"
+          data-testid="apply-option-radio"
+        >
+          <div>
+            <RadioButton
+              name="applyOptions"
+              :value="applyOption"
+              :val="APPLY_MODE.AUTOMATIC"
+              :label="automaticOptionLabel"
+              :mode="_EDIT"
+              :use-body-text-color="true"
+              @update:value="applyOption = $event"
+            >
+              <template #label>
+                {{ automaticOptionLabel }}
+                <i
+                  v-clean-tooltip="t('runtimeEnforcer.policyProposal.promoteDialog.applyStep.options.automatic.tooltip')"
+                  class="icon icon-info icon-lg option-tooltip-icon"
+                />
+              </template>
+            </RadioButton>
+          </div>
+
+          <div>
+            <RadioButton
+              name="applyOptions"
+              :value="applyOption"
+              :val="APPLY_MODE.MANUAL"
+              :label="manualOptionLabel"
+              :mode="_EDIT"
+              :use-body-text-color="true"
+              @update:value="applyOption = $event"
+            >
+              <template #label>
+                {{ manualOptionLabel }}
+                <i
+                  v-clean-tooltip="t('runtimeEnforcer.policyProposal.promoteDialog.applyStep.options.manual.tooltip')"
+                  class="icon icon-info icon-lg option-tooltip-icon"
+                />
+              </template>
+
+              <template #description>
+                <template v-if="applyOption === APPLY_MODE.MANUAL">
+                  <p class="confirm-text">
+                    <RichTranslation :k="manualDescriptionKey">
+                      <template #learnMore="{ content }">
+                        <SubtleLink
+                          :href="DOCUMENTATION_URL"
+                          target="_blank"
+                        >
+                          {{ content }}
+                        </SubtleLink>
+                      </template>
+                    </RichTranslation>
+                  </p>
+                  <div
+                    v-for="resource in resources"
+                    :key="resource.metadata.uid"
+                    class="mt-2"
+                  >
+                    <RcTag
+                      class="tag-row"
+                      :highlight="false"
+                    >
+                      <div class="tag-data">{{ WORKLOAD_PREFIX }} {{ resource.metadata.name }}</div>
+                    </RcTag>
+                    <CopyToClipboard class="cp-board" :value="`${ WORKLOAD_PREFIX } ${ resource.metadata.name }`" />
+                  </div>
+                </template>
+              </template>
+            </RadioButton>
+          </div>
+        </div>
+      </template>
+    </template>
+    <template #actions>
+      <RcButton
+        v-if="step === 1"
+        variant="link"
+        size="large"
+        @click="close"
+      >
+        {{ t('runtimeEnforcer.policyProposal.promoteDialog.cancel') }}
+      </RcButton>
+      <RcButton
+        v-if="step === 1"
+        variant="primary"
+        size="large"
+        class="ml-10"
+        @click="continueToApplyStep"
+      >
+        <i class="icon icon-upgrade-alt"></i>
+        {{ t('runtimeEnforcer.policyProposal.promoteDialog.promoteAndContinue') }}
+      </RcButton>
+      <RcButton
+        v-else
+        variant="primary"
+        size="large"
+        class="ml-10"
+        :disabled="promoteInProgress"
+        @click="finish"
+      >
+        {{ t('runtimeEnforcer.policyProposal.promoteDialog.finish') }}
+      </RcButton>
+    </template>
+  </Card>
+</template>
+
+
+<style lang="scss" scoped>
+.promote-policy-dialog-card {
+  box-shadow: none;
+  border-radius: var(--border-radius);
+
+  :deep(.card-actions) {
+    justify-content: end;
+  }
+
+  .banner {
+    margin: 16px 0 24px;
+  }
+
+  .confirm-text {
+    margin: 0 0 16px;
+  }
+
+  .mode-select {
+    margin-top: 16px;
+    margin-bottom: 20px;
+  }
+
+  .apply-option-group {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    margin-bottom: 16px;
+
+    :deep(.radio-button-outer-container-description) {
+      color: var(--body-text);
+      font-size: 14px;
+      margin-top: 16px;
+    }
+
+    .option-tooltip-icon {
+      margin-left: 8px;
+    }
+  }
+
+  .tag-row {
+    display: inline-flex;
+    align-items: center;
+    background-color: var(--rc-active-disabled-background);
+    border: 1px solid var(--rc-active-disabled-background);
+    border-radius: 4px;
+    margin: 6px 0;
+  }
+
+  .cp-board {
+    margin-left: -4px;
+  }
+
+  .tag-data {
+    display: inline-flex;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: calc(100%);
+    line-height: 21px;
+    font-family: Lato;
+    font-size: 13px;
+    font-weight: 400;
+    align-items: center;
+  }
+}
+</style>

--- a/pkg/runtime-enforcer/dialog/PromotePolicyDialog.vue
+++ b/pkg/runtime-enforcer/dialog/PromotePolicyDialog.vue
@@ -300,7 +300,6 @@ export default {
 <style lang="scss" scoped>
 .promote-policy-dialog-card {
   box-shadow: none;
-  border-radius: var(--border-radius);
 
   :deep(.card-actions) {
     justify-content: end;
@@ -356,7 +355,6 @@ export default {
     white-space: nowrap;
     max-width: calc(100%);
     line-height: 21px;
-    font-family: Lato;
     font-size: 13px;
     font-weight: 400;
     align-items: center;

--- a/pkg/runtime-enforcer/dialog/__tests__/DeleteActivePoliciesDialog.spec.ts
+++ b/pkg/runtime-enforcer/dialog/__tests__/DeleteActivePoliciesDialog.spec.ts
@@ -13,7 +13,7 @@ jest.mock('@shell/utils/error', () => ({
   exceptionToErrorsArray: jest.fn((err) => [err]),
 }));
 
-const t = jest.fn((key: string) => key);
+const t = jest.fn((key, args, raw) => (raw ? `${ key }:${ JSON.stringify(args) }` : key));
 
 const createResource = (name = 'policy-a', workloadName = 'wk-a') => ({
   nameDisplay: name,
@@ -63,7 +63,9 @@ describe('DeleteActivePoliciesDialog', () => {
       expect((wrapper.vm as any).isBulk).toBe(false);
       expect((wrapper.vm as any).title).toBe('runtimeEnforcer.activePolicies.deleteDialog.title.single');
       expect((wrapper.vm as any).bannerText).toBe('runtimeEnforcer.activePolicies.deleteDialog.banner.single');
-      expect((wrapper.vm as any).confirmText).toBe('runtimeEnforcer.activePolicies.deleteDialog.confirm.single');
+      expect((wrapper.vm as any).confirmText).toBe(
+        'runtimeEnforcer.activePolicies.deleteDialog.confirm.single:{"name":"nginx-policy"}'
+      );
       expect((wrapper.vm as any).manualRemovalText).toBe('runtimeEnforcer.activePolicies.deleteDialog.manualRemoval.single');
     });
 
@@ -73,7 +75,9 @@ describe('DeleteActivePoliciesDialog', () => {
       expect((wrapper.vm as any).isBulk).toBe(true);
       expect((wrapper.vm as any).title).toBe('runtimeEnforcer.activePolicies.deleteDialog.title.bulk');
       expect((wrapper.vm as any).bannerText).toBe('runtimeEnforcer.activePolicies.deleteDialog.banner.bulk');
-      expect((wrapper.vm as any).confirmText).toBe('runtimeEnforcer.activePolicies.deleteDialog.confirm.bulk');
+      expect((wrapper.vm as any).confirmText).toBe(
+        'runtimeEnforcer.activePolicies.deleteDialog.confirm.bulk:{"count":2}'
+      );
       expect((wrapper.vm as any).manualRemovalText).toBe('runtimeEnforcer.activePolicies.deleteDialog.manualRemoval.bulk');
     });
   });
@@ -203,6 +207,24 @@ describe('DeleteActivePoliciesDialog', () => {
     });
   });
 
+  describe('computed: growlTitle', () => {
+    it('returns single growl title with name', () => {
+      const { wrapper } = mountDialog({ resources: [createResource('nginx-policy', 'nginx')] });
+
+      expect((wrapper.vm as any).growlTitle).toBe(
+        'runtimeEnforcer.activePolicies.deleteDialog.growl.title.single:{"name":"nginx-policy"}'
+      );
+    });
+
+    it('returns bulk growl title with count', () => {
+      const { wrapper } = mountDialog({ resources: [createResource('a'), createResource('b')] });
+
+      expect((wrapper.vm as any).growlTitle).toBe(
+        'runtimeEnforcer.activePolicies.deleteDialog.growl.title.bulk:{"count":2}'
+      );
+    });
+  });
+
   describe('close', () => {
     it('emits close', () => {
       const { wrapper } = mountDialog();
@@ -266,6 +288,7 @@ describe('DeleteActivePoliciesDialog', () => {
       expect(resources[1].remove).toHaveBeenCalledTimes(1);
       expect(redeploySpy).not.toHaveBeenCalled();
       expect(dispatch).toHaveBeenCalledWith('growl/success', {
+        title:   'runtimeEnforcer.activePolicies.deleteDialog.growl.title.bulk:{"count":2}',
         message: 'runtimeEnforcer.activePolicies.deleteDialog.growl.delete.bulk',
       });
       expect(push).toHaveBeenCalledWith({
@@ -289,6 +312,7 @@ describe('DeleteActivePoliciesDialog', () => {
       expect(resources[1].remove).toHaveBeenCalledTimes(1);
       expect(redeploySpy).toHaveBeenCalledTimes(2);
       expect(dispatch).toHaveBeenCalledWith('growl/success', {
+        title:   'runtimeEnforcer.activePolicies.deleteDialog.growl.title.bulk:{"count":2}',
         message: 'runtimeEnforcer.activePolicies.deleteDialog.growl.delete.bulk runtimeEnforcer.activePolicies.deleteDialog.growl.autoRemoval.bulk',
       });
       expect((wrapper.vm as any).deleteInProgress).toBe(false);
@@ -306,6 +330,7 @@ describe('DeleteActivePoliciesDialog', () => {
 
       expect(redeploySpy).not.toHaveBeenCalled();
       expect(dispatch).toHaveBeenCalledWith('growl/success', {
+        title:   'runtimeEnforcer.activePolicies.deleteDialog.growl.title.single:{"name":"a"}',
         message: 'runtimeEnforcer.activePolicies.deleteDialog.growl.delete.single runtimeEnforcer.activePolicies.deleteDialog.growl.manualRemoval.single',
       });
       expect((wrapper.vm as any).deleteInProgress).toBe(false);

--- a/pkg/runtime-enforcer/dialog/__tests__/DeletePolicyProposalsDialog.spec.ts
+++ b/pkg/runtime-enforcer/dialog/__tests__/DeletePolicyProposalsDialog.spec.ts
@@ -56,6 +56,9 @@ describe('DeletePolicyProposalsDialog', () => {
         'runtimeEnforcer.policyProposal.deleteDialog.confirm.single:{"name":"single-policy","workload":"wk-1"}'
       );
       expect((wrapper.vm as any).growlMessage).toBe('runtimeEnforcer.policyProposal.deleteDialog.growl.single');
+      expect((wrapper.vm as any).growlTitle).toBe(
+        'runtimeEnforcer.policyProposal.deleteDialog.growl.title.single:{"name":"single-policy"}'
+      );
     });
 
     it('is bulk and uses bulk copy for multiple resources', () => {
@@ -71,6 +74,9 @@ describe('DeletePolicyProposalsDialog', () => {
         'runtimeEnforcer.policyProposal.deleteDialog.confirm.bulk:{"count":2}'
       );
       expect((wrapper.vm as any).growlMessage).toBe('runtimeEnforcer.policyProposal.deleteDialog.growl.bulk');
+      expect((wrapper.vm as any).growlTitle).toBe(
+        'runtimeEnforcer.policyProposal.deleteDialog.growl.title.bulk:{"count":2}'
+      );
     });
   });
 
@@ -148,6 +154,7 @@ describe('DeletePolicyProposalsDialog', () => {
       expect(redeploySpy).toHaveBeenNthCalledWith(2, resources[1]);
       expect((wrapper.vm as any).deleteInProgress).toBe(false);
       expect(dispatch).toHaveBeenCalledWith('growl/success', {
+        title:   'runtimeEnforcer.policyProposal.deleteDialog.growl.title.bulk:{"count":2}',
         message: 'runtimeEnforcer.policyProposal.deleteDialog.growl.bulk',
       });
       expect(push).toHaveBeenCalledWith({

--- a/pkg/runtime-enforcer/dialog/__tests__/PromotePolicyDialog.spec.ts
+++ b/pkg/runtime-enforcer/dialog/__tests__/PromotePolicyDialog.spec.ts
@@ -1,0 +1,232 @@
+import { shallowMount } from '@vue/test-utils';
+import PromotePolicyDialog from '../PromotePolicyDialog.vue';
+import { PRODUCT_NAME, POLICY_MODE, APPLY_MODE } from '@runtime-enforcer/types/runtime-enforcer.ts';
+
+jest.mock('@shell/components/Resource/Detail/CopyToClipboard.vue', () => ({
+  __esModule: true,
+  default:    { name: 'CopyToClipboard', template: '<div />' },
+}));
+
+jest.mock('../../utils/promote', () => ({
+  applyPromoteLabel:   jest.fn().mockResolvedValue(undefined),
+  snapshotProposal:    jest.fn((resource) => ({ snapshot: resource.nameDisplay })),
+  runPromoteFollowUps: jest.fn(),
+}));
+
+import { applyPromoteLabel, snapshotProposal, runPromoteFollowUps } from '../../utils/promote';
+
+const t = jest.fn((key: string, args?: Record<string, any>) => (args ? `${ key } ${ JSON.stringify(args) }` : key));
+
+const createResource = (name = 'proposal-a', workload = 'wk-a') => ({
+  nameDisplay: name,
+  workload,
+  metadata:    { uid: `${ name }-uid`, name },
+});
+
+const mountDialog = ({
+  resources = [createResource()],
+  dispatch,
+  push = jest.fn(),
+} = {}) => {
+  const storeDispatch = dispatch || jest.fn();
+
+  return {
+    wrapper: shallowMount(PromotePolicyDialog as any, {
+      props:  { resources },
+      global: {
+        mocks: {
+          t,
+          $store:  { dispatch: storeDispatch },
+          $router: { push },
+          $route:  { params: { cluster: 'local' } },
+        },
+      },
+    }),
+    storeDispatch,
+    push,
+  };
+};
+
+describe('PromotePolicyDialog', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('computed: isBulk / title', () => {
+    it('is single for one resource', () => {
+      const { wrapper } = mountDialog({ resources: [createResource()] });
+
+      expect((wrapper.vm as any).isBulk).toBe(false);
+      expect((wrapper.vm as any).title).toBe('runtimeEnforcer.policyProposal.promoteDialog.title.single');
+    });
+
+    it('is bulk for multiple resources', () => {
+      const { wrapper } = mountDialog({ resources: [createResource('a'), createResource('b')] });
+
+      expect((wrapper.vm as any).isBulk).toBe(true);
+      expect((wrapper.vm as any).title).toBe('runtimeEnforcer.policyProposal.promoteDialog.title.bulk');
+    });
+
+    it('uses applyStep title on step 2', () => {
+      const { wrapper } = mountDialog();
+
+      (wrapper.vm as any).step = 2;
+      expect((wrapper.vm as any).title).toBe('runtimeEnforcer.policyProposal.promoteDialog.applyStep.title.single');
+    });
+  });
+
+  describe('computed: bannerText', () => {
+    it('interpolates workload name on step 2', () => {
+      const { wrapper } = mountDialog({ resources: [createResource('proposal-a', 'nginx')] });
+
+      (wrapper.vm as any).step = 2;
+      expect((wrapper.vm as any).bannerText).toBe(
+        'runtimeEnforcer.policyProposal.promoteDialog.applyStep.banner.single {"name":"nginx"}'
+      );
+    });
+  });
+
+  describe('computed: confirmText', () => {
+    it('uses single confirm text with name', () => {
+      const { wrapper } = mountDialog({ resources: [createResource('proposal-a')] });
+
+      expect((wrapper.vm as any).confirmText).toBe(
+        'runtimeEnforcer.policyProposal.promoteDialog.confirm.single {"name":"proposal-a"}'
+      );
+    });
+
+    it('uses bulk confirm text with count', () => {
+      const { wrapper } = mountDialog({ resources: [createResource('a'), createResource('b')] });
+
+      expect((wrapper.vm as any).confirmText).toBe(
+        'runtimeEnforcer.policyProposal.promoteDialog.confirm.bulk {"count":2}'
+      );
+    });
+  });
+
+  describe('computed: growlTitle / growlMessage', () => {
+    it('builds single growl title and message for automatic apply', () => {
+      const { wrapper } = mountDialog({ resources: [createResource('proposal-a')] });
+
+      (wrapper.vm as any).applyOption = APPLY_MODE.AUTOMATIC;
+      expect((wrapper.vm as any).growlTitle).toBe(
+        'runtimeEnforcer.policyProposal.promoteDialog.growl.title.single {"name":"proposal-a"}'
+      );
+      expect((wrapper.vm as any).growlMessage).toBe(
+        'runtimeEnforcer.policyProposal.promoteDialog.growl.base.single {} runtimeEnforcer.policyProposal.promoteDialog.growl.automatic.single {}'
+      );
+    });
+
+    it('builds bulk growl title and message for manual apply', () => {
+      const { wrapper } = mountDialog({ resources: [createResource('a'), createResource('b')] });
+
+      (wrapper.vm as any).applyOption = APPLY_MODE.MANUAL;
+      expect((wrapper.vm as any).growlTitle).toBe(
+        'runtimeEnforcer.policyProposal.promoteDialog.growl.title.bulk {"count":2}'
+      );
+      expect((wrapper.vm as any).growlMessage).toBe(
+        'runtimeEnforcer.policyProposal.promoteDialog.growl.base.bulk {"count":2} runtimeEnforcer.policyProposal.promoteDialog.growl.manual.bulk {}'
+      );
+    });
+  });
+
+  describe('close', () => {
+    it('emits close', () => {
+      const { wrapper } = mountDialog();
+
+      (wrapper.vm as any).close();
+
+      expect(wrapper.emitted('close')).toHaveLength(1);
+    });
+  });
+
+  describe('continueToApplyStep', () => {
+    it('advances to step 2', () => {
+      const { wrapper } = mountDialog();
+
+      (wrapper.vm as any).continueToApplyStep();
+
+      expect((wrapper.vm as any).step).toBe(2);
+    });
+  });
+
+  describe('finish', () => {
+    it('applies labels, runs follow-ups, dispatches growl, and routes for single resource', async() => {
+      const resource = createResource('proposal-a', 'wk-a');
+      const dispatch = jest.fn();
+      const push = jest.fn();
+      const { wrapper } = mountDialog({
+        resources: [resource], dispatch, push
+      });
+
+      (wrapper.vm as any).applyOption = APPLY_MODE.AUTOMATIC;
+      (wrapper.vm as any).targetMode = POLICY_MODE.PROTECT;
+
+      await (wrapper.vm as any).finish();
+
+      expect(applyPromoteLabel).toHaveBeenCalledWith(resource);
+      expect(snapshotProposal).toHaveBeenCalledWith(resource);
+      expect(runPromoteFollowUps).toHaveBeenCalledWith(
+        { dispatch },
+        { snapshot: 'proposal-a' },
+        { targetMode: POLICY_MODE.PROTECT, autoApply: true }
+      );
+      expect(dispatch).toHaveBeenCalledWith('growl/success', {
+        title:   (wrapper.vm as any).growlTitle,
+        message: (wrapper.vm as any).growlMessage,
+      });
+      expect(push).toHaveBeenCalledWith({
+        name:   `c-cluster-${ PRODUCT_NAME }-resource`,
+        params: { cluster: 'local', product: PRODUCT_NAME },
+      });
+      expect((wrapper.vm as any).promoteInProgress).toBe(false);
+      expect(wrapper.emitted('close')).toHaveLength(1);
+    });
+
+    it('does not route when bulk', async() => {
+      const resources = [createResource('a'), createResource('b')];
+      const push = jest.fn();
+      const { wrapper } = mountDialog({ resources, push });
+
+      await (wrapper.vm as any).finish();
+
+      expect(push).not.toHaveBeenCalled();
+      expect(wrapper.emitted('close')).toHaveLength(1);
+    });
+
+    it('sets autoApply false when manual option selected', async() => {
+      const resource = createResource('proposal-a');
+      const { wrapper } = mountDialog({ resources: [resource] });
+
+      (wrapper.vm as any).applyOption = APPLY_MODE.MANUAL;
+      await (wrapper.vm as any).finish();
+
+      expect(runPromoteFollowUps).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ autoApply: false })
+      );
+    });
+
+    it('dispatches growl/fromError and keeps dialog open when applyPromoteLabel fails', async() => {
+      const err = new Error('boom');
+
+      (applyPromoteLabel as jest.Mock).mockRejectedValueOnce(err);
+
+      const dispatch = jest.fn();
+      const push = jest.fn();
+      const { wrapper } = mountDialog({ dispatch, push });
+
+      await (wrapper.vm as any).finish();
+
+      expect(dispatch).toHaveBeenCalledWith('growl/fromError', {
+        title: 'runtimeEnforcer.policyProposal.promoteDialog.errorTitle',
+        err,
+      });
+      expect(runPromoteFollowUps).not.toHaveBeenCalled();
+      expect(push).not.toHaveBeenCalled();
+      expect((wrapper.vm as any).promoteInProgress).toBe(false);
+      expect(wrapper.emitted('close')).toBeUndefined();
+    });
+  });
+});

--- a/pkg/runtime-enforcer/formatters/PromoteButton.vue
+++ b/pkg/runtime-enforcer/formatters/PromoteButton.vue
@@ -2,7 +2,7 @@
   <RcButton
     variant="secondary"
     size="medium"
-    @click="promoteFn()"
+    @click="row.promote()"
   >
     <i class="icon icon-upgrade-alt"></i>
     {{ t('runtimeEnforcer.policyProposals.actions.promote') }}
@@ -23,10 +23,6 @@ export default {
       type:    Object,
       default: () => ({})
     },
-    promoteFn: {
-      type:    Function,
-      required: true
-    }
   }
 };
 </script>

--- a/pkg/runtime-enforcer/l10n/en-us.yaml
+++ b/pkg/runtime-enforcer/l10n/en-us.yaml
@@ -150,6 +150,55 @@ runtimeEnforcer:
       growl:
         single: The policy proposal has been successfully deleted. Restarting the corresponding workload might take a few minutes to complete.
         bulk: The selected policy proposals ({count}) have been successfully deleted. Restarting the corresponding workloads might take a few minutes to complete.
+    promoteDialog:
+      title:
+        single: Promote policy proposal to active policy
+        bulk: Promote policy proposals to active policies
+      banner:
+        single: Promoting will create the active policy CRD and delete the proposal permanently afterwards. <b>This action cannot be undone.</b>
+        bulk: For each proposal, promoting will create the active policy CRD and delete the proposal permanently afterwards. <b>This action cannot be undone.</b>
+      confirm:
+        single: 'Are you sure you want to promote the <b>{name}</b> policy proposal to active policy? If so, please select the target mode below to continue.'
+        bulk: 'Are you sure you want to promote the <b>selected policy proposals ({count})</b> to active policies? If so, please select the target mode below to continue.'
+      mode:
+        monitor: Monitor mode
+        protect: Protect mode
+      cancel: Cancel
+      promoteAndContinue: Promote and Continue
+      applyStep:
+        title:
+          single: Apply the active policy on the workload
+          bulk: Apply the active policies on the workloads
+        banner:
+          single: If the <b>{name}</b> workload is managed via GitOps (e.g., Fleet), we recommend manually applying the new active policy. Otherwise, the next (re)deployment will overwrite or remove the generated policy label.
+          bulk: If at least one workload is managed via GitOps (e.g., Fleet), we recommend manually applying the new active policies. Otherwise, the next (re)deployment will overwrite or remove the generated policy labels.
+        options:
+          automatic:
+            single: Automatically apply the active policy and restart the workload
+            bulk: Automatically apply the active policies and restart the workloads
+            tooltip: runtimeEnforcer.policyProposal.promoteDialog.applyStep.options.automatic.tooltip
+          manual:
+            single: Manually apply the active policy (recommended for GitOps)
+            bulk: Manually apply the active policies (recommended for GitOps)
+            tooltip: runtimeEnforcer.policyProposal.promoteDialog.applyStep.options.manual.tooltip
+        manualDescription:
+          single: To manually apply the active policy on the workload, you need to copy the label below on the corresponding workload and redeploy it. <learnMore>Learn more</learnMore>
+          bulk: To manually apply the active policies on the workloads, you need to copy the labels below on the corresponding workloads and redeploy them. <learnMore>Learn more</learnMore>
+      finish: Finish
+      errorTitle: Failed to promote policy proposal
+      growl:
+        title:
+          single: '{name} has been promoted to active policy'
+          bulk: Selected policy proposals ({count}) have been promoted to active policies
+        base:
+          single: The policy proposal has been successfully promoted to an active policy.
+          bulk: The selected policy proposals ({count}) have been successfully promoted to active policies.
+        manual:
+          single: Don't forget to manually apply the active policy on the corresponding workload and redeploy it.
+          bulk: Don't forget to manually apply the active policies on the corresponding workloads and redeploy them.
+        automatic:
+          single: Restarting the corresponding workload might take a few minutes to complete.
+          bulk: Restarting the corresponding workloads might take a few minutes to complete.
     errors:
       emptyPath: "Container {container}: Executable path at position {index} cannot be empty."
       invalidPath: "Container {container}: Executable path {path} must start with a leading slash /."

--- a/pkg/runtime-enforcer/l10n/en-us.yaml
+++ b/pkg/runtime-enforcer/l10n/en-us.yaml
@@ -148,6 +148,9 @@ runtimeEnforcer:
         single: Delete Proposal and Restart Workload
         bulk: Delete Proposals and Restart Workloads
       growl:
+        title:
+          single: '{name} has been deleted'
+          bulk: Selected policy proposals ({count}) have been deleted
         single: The policy proposal has been successfully deleted. Restarting the corresponding workload might take a few minutes to complete.
         bulk: The selected policy proposals ({count}) have been successfully deleted. Restarting the corresponding workloads might take a few minutes to complete.
     promoteDialog:
@@ -295,6 +298,9 @@ runtimeEnforcer:
         single: Delete Policy and Restart Workload
         bulk: Delete Policies and Restart Workloads
       growl:
+        title:
+          single: '{name} has been deleted'
+          bulk: Selected active policies ({count}) have been deleted
         delete:
           single: The{name} active policy has been successfully deleted.
           bulk: The selected active policies ({count}) have been successfully deleted.

--- a/pkg/runtime-enforcer/list/security.rancher.io.workloadpolicyproposal.vue
+++ b/pkg/runtime-enforcer/list/security.rancher.io.workloadpolicyproposal.vue
@@ -149,6 +149,18 @@ function filterRowsApi(pagination: any) {
   return pagination;
 }
 
+function promoteSelected() {
+  if (!selectedRows.value.length) {
+    return;
+  }
+
+  store.dispatch('cluster/promptModal', {
+    component:  'PromotePolicyDialog',
+    resources:  Array.isArray(selectedRows.value) ? [...selectedRows.value] : [selectedRows.value],
+    modalWidth: '640',
+  });
+}
+
 function exportSelected() {
   if (!selectedRows.value.length) {
     return;
@@ -253,6 +265,7 @@ function deleteSelected() {
             variant="primary"
             size="medium"
             :disabled="!selectedRows.length"
+            @click="promoteSelected"
           >
             <i class="icon icon-upgrade-alt"></i>
             {{ t('runtimeEnforcer.policyProposals.actions.promote') }}

--- a/pkg/runtime-enforcer/models/security.rancher.io.workloadpolicyproposal.js
+++ b/pkg/runtime-enforcer/models/security.rancher.io.workloadpolicyproposal.js
@@ -130,10 +130,10 @@ export default class WorkloadPolicyProposal extends SteveModel {
   get childrenRec() {
     return Object.entries(this.rulesByContainer).map(([containerName, containerRules]) => {
       return {
-        container:   containerName,
-        image:       containerRules?.image || '',
+        container:       containerName,
+        image:           containerRules?.image || '',
         executableCount: containerRules?.executables?.allowed?.length || 0,
-        executables: containerRules?.executables?.allowed || [],
+        executables:     containerRules?.executables?.allowed || [],
       };
     });
   }
@@ -165,9 +165,12 @@ export default class WorkloadPolicyProposal extends SteveModel {
     });
   }
 
-  promote() {
-    // eslint-disable-next-line no-console
-    console.warn('WorkloadPolicyProposal.promote() is not yet implemented.');
+  promote(resources = this) {
+    this.$dispatch('promptModal', {
+      component:  'PromotePolicyDialog',
+      resources:  Array.isArray(resources) ? resources : [resources],
+      modalWidth: '640',
+    });
   }
 
 }

--- a/pkg/runtime-enforcer/types/runtime-enforcer.ts
+++ b/pkg/runtime-enforcer/types/runtime-enforcer.ts
@@ -3,7 +3,7 @@ export const PRODUCT_NAME = 'runtimeEnforcer';
 export const CHART_REGISTRY_URL = 'oci://dp.apps.rancher.io/charts';
 export const DOCKER_CONFIG_JSON_TYPE = '.dockerconfigjson';
 
-export const RESOURCE = { 
+export const RESOURCE = {
   POLICY_PROPOSALS: 'security.rancher.io.workloadpolicyproposal',
   ACTIVE_POLICIES:  'security.rancher.io.workloadpolicy',
 };
@@ -152,3 +152,17 @@ export const POLICY_STATUS = {
 export const DOCUMENTATION_URL = 'https://github.com/rancher-sandbox/runtime-enforcer/tree/main/docs';
 
 export const WORKLOAD_PREFIX = 'security.rancher.io/policy :';
+
+export const POLICY_LABEL_KEY = 'security.rancher.io/policy';
+
+export const PROMOTE_LABEL_KEY = 'security.rancher.io/promote';
+
+export const APPLY_MODE = {
+  AUTOMATIC: 'automatic',
+  MANUAL:    'manual',
+} as const;
+
+export type ApplyMode = typeof APPLY_MODE[keyof typeof APPLY_MODE];
+
+// Client-side cutoff for the background watch that waits for a promoted proposal's WorkloadPolicy to appear
+export const PROMOTE_WATCH_TIMEOUT_MS = 20000;

--- a/pkg/runtime-enforcer/utils/__tests__/promote.spec.ts
+++ b/pkg/runtime-enforcer/utils/__tests__/promote.spec.ts
@@ -1,0 +1,311 @@
+import { jest } from '@jest/globals';
+import { RESOURCE, POLICY_MODE } from '../../types/runtime-enforcer';
+
+const mockWaitFor = jest.fn();
+
+jest.mock('@shell/utils/async', () => ({ waitFor: (...args: any[]) => mockWaitFor(...args) }));
+
+import {
+  snapshotProposal, applyPromoteLabel, applyWorkloadPolicyLabel, watchAndApplyProtectMode, runPromoteFollowUps
+} from '../promote';
+
+const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('snapshotProposal', () => {
+  it('extracts namespace, name, workload name and owner steve type from a resource', () => {
+    const resource = {
+      metadata:               { namespace: 'ns-1', name: 'proposal-1' },
+      workload:               'my-deployment',
+      ownerWorkloadSteveType: 'apps.deployment',
+    };
+
+    expect(snapshotProposal(resource)).toEqual({
+      namespace:              'ns-1',
+      name:                   'proposal-1',
+      workloadName:           'my-deployment',
+      ownerWorkloadSteveType: 'apps.deployment',
+    });
+  });
+
+  it('gracefully handles a resource missing metadata/workload fields', () => {
+    expect(snapshotProposal({})).toEqual({
+      namespace:              undefined,
+      name:                   undefined,
+      workloadName:           undefined,
+      ownerWorkloadSteveType: undefined,
+    });
+  });
+
+  it('gracefully handles undefined/null resource', () => {
+    expect(snapshotProposal(undefined)).toEqual({
+      namespace:              undefined,
+      name:                   undefined,
+      workloadName:           undefined,
+      ownerWorkloadSteveType: undefined,
+    });
+  });
+});
+
+describe('applyPromoteLabel', () => {
+  it('sets the promote label and saves the resource', async() => {
+    const resource: any = {
+      metadata: { labels: { existing: 'label' } },
+      save:     jest.fn().mockResolvedValue(undefined),
+    };
+
+    await applyPromoteLabel(resource);
+
+    expect(resource.metadata.labels).toEqual({
+      existing:                      'label',
+      'security.rancher.io/promote': 'true',
+    });
+    expect(resource.save).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates metadata/labels objects when missing', async() => {
+    const resource: any = { save: jest.fn().mockResolvedValue(undefined) };
+
+    await applyPromoteLabel(resource);
+
+    expect(resource.metadata.labels['security.rancher.io/promote']).toBe('true');
+    expect(resource.save).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('applyWorkloadPolicyLabel', () => {
+  const baseSnapshot = {
+    namespace:              'ns-1',
+    name:                   'proposal-1',
+    workloadName:           'my-deployment',
+    ownerWorkloadSteveType: 'apps.deployment',
+  };
+
+  it.each([
+    ['namespace', { ...baseSnapshot, namespace: undefined }],
+    ['name', { ...baseSnapshot, name: undefined }],
+    ['workloadName', { ...baseSnapshot, workloadName: undefined }],
+    ['ownerWorkloadSteveType', { ...baseSnapshot, ownerWorkloadSteveType: undefined }],
+  ])('returns early without dispatching when %s is missing', async(_field, snapshot) => {
+    const store: any = { dispatch: jest.fn() };
+
+    await applyWorkloadPolicyLabel(store, snapshot as any);
+
+    expect(store.dispatch).not.toHaveBeenCalled();
+  });
+
+  it('returns early when the workload cannot be found', async() => {
+    const store: any = { dispatch: jest.fn().mockResolvedValue(undefined) };
+
+    await applyWorkloadPolicyLabel(store, baseSnapshot);
+
+    expect(store.dispatch).toHaveBeenCalledWith('cluster/find', {
+      type: 'apps.deployment',
+      id:   'ns-1/my-deployment',
+    });
+  });
+
+  it('returns early when the workload has no pod template', async() => {
+    const workload = { spec: {}, save: jest.fn() };
+    const store: any = { dispatch: jest.fn().mockResolvedValue(workload) };
+
+    await applyWorkloadPolicyLabel(store, baseSnapshot);
+
+    expect(workload.save).not.toHaveBeenCalled();
+  });
+
+  it('sets the policy label on spec.template for standard workloads and saves', async() => {
+    const workload: any = { spec: { template: {} }, save: jest.fn().mockResolvedValue(undefined) };
+    const store: any = { dispatch: jest.fn().mockResolvedValue(workload) };
+
+    await applyWorkloadPolicyLabel(store, baseSnapshot);
+
+    expect(workload.spec.template.metadata.labels['security.rancher.io/policy']).toBe('proposal-1');
+    expect(workload.save).toHaveBeenCalledTimes(1);
+  });
+
+  it('sets the policy label on spec.jobTemplate.spec.template for CronJobs and saves', async() => {
+    const workload: any = { spec: { jobTemplate: { spec: { template: {} } } }, save: jest.fn().mockResolvedValue(undefined) };
+    const store: any = { dispatch: jest.fn().mockResolvedValue(workload) };
+
+    await applyWorkloadPolicyLabel(store, { ...baseSnapshot, ownerWorkloadSteveType: 'batch.cronjob' });
+
+    expect(workload.spec.jobTemplate.spec.template.metadata.labels['security.rancher.io/policy']).toBe('proposal-1');
+    expect(workload.save).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves existing pod template labels when adding the policy label', async() => {
+    const workload: any = {
+      spec: { template: { metadata: { labels: { app: 'my-deployment' } } } },
+      save: jest.fn().mockResolvedValue(undefined),
+    };
+    const store: any = { dispatch: jest.fn().mockResolvedValue(workload) };
+
+    await applyWorkloadPolicyLabel(store, baseSnapshot);
+
+    expect(workload.spec.template.metadata.labels).toEqual({
+      app:                          'my-deployment',
+      'security.rancher.io/policy': 'proposal-1',
+    });
+  });
+});
+
+describe('watchAndApplyProtectMode', () => {
+  const snapshot = { namespace: 'ns-1', name: 'proposal-1' };
+  const policyId = 'ns-1/proposal-1';
+
+  beforeEach(() => {
+    mockWaitFor.mockReset();
+  });
+
+  it('returns early without dispatching when namespace or name is missing', async() => {
+    const store: any = { dispatch: jest.fn(), getters: {} };
+
+    await watchAndApplyProtectMode(store, { namespace: undefined, name: 'proposal-1' });
+    await watchAndApplyProtectMode(store, { namespace: 'ns-1', name: undefined });
+
+    expect(store.dispatch).not.toHaveBeenCalled();
+    expect(mockWaitFor).not.toHaveBeenCalled();
+  });
+
+  it('subscribes to the active policies watch and waits for the policy to appear', async() => {
+    const policy = { spec: {}, save: jest.fn().mockResolvedValue(undefined) };
+    const store: any = {
+      dispatch: jest.fn().mockResolvedValue(undefined),
+      getters:  { 'cluster/byId': jest.fn().mockReturnValue(policy) },
+    };
+
+    mockWaitFor.mockResolvedValue(undefined);
+
+    await watchAndApplyProtectMode(store, snapshot, 12345);
+
+    expect(store.dispatch).toHaveBeenCalledWith('cluster/findAll', { type: RESOURCE.ACTIVE_POLICIES, opt: { watch: true } });
+    expect(mockWaitFor).toHaveBeenCalledWith(expect.any(Function), `policy ${ policyId } to be created`, 12345);
+
+    // Exercise the predicate passed to waitFor to confirm it checks the right getter/id.
+    const predicate = mockWaitFor.mock.calls[0][0] as () => boolean;
+
+    expect(predicate()).toBe(true);
+    expect(store.getters['cluster/byId']).toHaveBeenCalledWith(RESOURCE.ACTIVE_POLICIES, policyId);
+  });
+
+  it('sets the policy to Protect mode and saves once the wait resolves', async() => {
+    const policy: any = { spec: {}, save: jest.fn().mockResolvedValue(undefined) };
+    const store: any = {
+      dispatch: jest.fn().mockResolvedValue(undefined),
+      getters:  { 'cluster/byId': jest.fn().mockReturnValue(policy) },
+    };
+
+    mockWaitFor.mockResolvedValue(undefined);
+
+    await watchAndApplyProtectMode(store, snapshot);
+
+    expect(policy.spec.mode).toBe(POLICY_MODE.PROTECT);
+    expect(policy.save).toHaveBeenCalledTimes(1);
+  });
+
+  it('silently returns when the wait times out', async() => {
+    const store: any = {
+      dispatch: jest.fn().mockResolvedValue(undefined),
+      getters:  { 'cluster/byId': jest.fn() },
+    };
+
+    mockWaitFor.mockRejectedValue(new Error('timed out'));
+
+    await expect(watchAndApplyProtectMode(store, snapshot)).resolves.toBeUndefined();
+    expect(store.getters['cluster/byId']).not.toHaveBeenCalledWith(RESOURCE.ACTIVE_POLICIES, policyId);
+  });
+
+  it('silently returns if the policy is missing after the wait resolves', async() => {
+    const store: any = {
+      dispatch: jest.fn().mockResolvedValue(undefined),
+      getters:  { 'cluster/byId': jest.fn().mockReturnValue(undefined) },
+    };
+
+    mockWaitFor.mockResolvedValue(undefined);
+
+    await expect(watchAndApplyProtectMode(store, snapshot)).resolves.toBeUndefined();
+  });
+});
+
+describe('runPromoteFollowUps', () => {
+  beforeEach(() => {
+    mockWaitFor.mockReset();
+  });
+
+  it('applies the workload policy label when autoApply is true', async() => {
+    const workload: any = { spec: { template: {} }, save: jest.fn().mockResolvedValue(undefined) };
+    const store: any = { dispatch: jest.fn().mockResolvedValue(workload) };
+    const snapshot = {
+      namespace: 'ns-1', name: 'proposal-1', workloadName: 'my-deployment', ownerWorkloadSteveType: 'apps.deployment',
+    };
+
+    runPromoteFollowUps(store, snapshot, { targetMode: POLICY_MODE.MONITOR, autoApply: true });
+    await flushPromises();
+
+    expect(store.dispatch).toHaveBeenCalledWith('cluster/find', { type: 'apps.deployment', id: 'ns-1/my-deployment' });
+    expect(workload.save).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not apply the workload policy label when autoApply is false', async() => {
+    const store: any = { dispatch: jest.fn().mockResolvedValue(undefined) };
+    const snapshot = {
+      namespace: 'ns-1', name: 'proposal-1', workloadName: 'my-deployment', ownerWorkloadSteveType: 'apps.deployment',
+    };
+
+    runPromoteFollowUps(store, snapshot, { targetMode: POLICY_MODE.MONITOR, autoApply: false });
+    await flushPromises();
+
+    expect(store.dispatch).not.toHaveBeenCalledWith('cluster/find', expect.anything());
+  });
+
+  it('watches for and applies Protect mode when targetMode is protect', async() => {
+    const policy: any = { spec: {}, save: jest.fn().mockResolvedValue(undefined) };
+    const store: any = {
+      dispatch: jest.fn().mockResolvedValue(undefined),
+      getters:  { 'cluster/byId': jest.fn().mockReturnValue(policy) },
+    };
+    const snapshot = { namespace: 'ns-1', name: 'proposal-1' };
+
+    mockWaitFor.mockResolvedValue(undefined);
+
+    runPromoteFollowUps(store, snapshot, { targetMode: POLICY_MODE.PROTECT, autoApply: false });
+    await flushPromises();
+
+    expect(store.dispatch).toHaveBeenCalledWith('cluster/findAll', { type: RESOURCE.ACTIVE_POLICIES, opt: { watch: true } });
+    expect(policy.spec.mode).toBe(POLICY_MODE.PROTECT);
+  });
+
+  it('does not watch for Protect mode when targetMode is monitor', async() => {
+    const store: any = { dispatch: jest.fn().mockResolvedValue(undefined) };
+    const snapshot = { namespace: 'ns-1', name: 'proposal-1' };
+
+    runPromoteFollowUps(store, snapshot, { targetMode: POLICY_MODE.MONITOR, autoApply: false });
+    await flushPromises();
+
+    expect(mockWaitFor).not.toHaveBeenCalled();
+  });
+
+  it('swallows errors from applyWorkloadPolicyLabel without throwing', async() => {
+    const store: any = { dispatch: jest.fn().mockRejectedValue(new Error('boom')) };
+    const snapshot = {
+      namespace: 'ns-1', name: 'proposal-1', workloadName: 'my-deployment', ownerWorkloadSteveType: 'apps.deployment',
+    };
+
+    expect(() => {
+      runPromoteFollowUps(store, snapshot, { targetMode: POLICY_MODE.MONITOR, autoApply: true });
+    }).not.toThrow();
+
+    await flushPromises();
+  });
+
+  it('swallows errors from watchAndApplyProtectMode without throwing', async() => {
+    const store: any = { dispatch: jest.fn().mockRejectedValue(new Error('boom')) };
+    const snapshot = { namespace: 'ns-1', name: 'proposal-1' };
+
+    expect(() => {
+      runPromoteFollowUps(store, snapshot, { targetMode: POLICY_MODE.PROTECT, autoApply: false });
+    }).not.toThrow();
+
+    await flushPromises();
+  });
+});

--- a/pkg/runtime-enforcer/utils/promote.ts
+++ b/pkg/runtime-enforcer/utils/promote.ts
@@ -1,0 +1,117 @@
+import { waitFor } from '@shell/utils/async';
+
+import {
+  RESOURCE, POLICY_MODE, POLICY_LABEL_KEY, PROMOTE_LABEL_KEY, PROMOTE_WATCH_TIMEOUT_MS
+} from '../types/runtime-enforcer';
+
+export interface PromoteOptions {
+  targetMode: string;
+  autoApply: boolean;
+}
+
+export interface ProposalSnapshot {
+  namespace?: string;
+  name?: string;
+  workloadName?: string;
+  ownerWorkloadSteveType?: string;
+}
+
+export function snapshotProposal(resource: any): ProposalSnapshot {
+  return {
+    namespace:              resource?.metadata?.namespace,
+    name:                   resource?.metadata?.name,
+    workloadName:           resource?.workload,
+    ownerWorkloadSteveType: resource?.ownerWorkloadSteveType,
+  };
+}
+
+export async function applyPromoteLabel(resource: any): Promise<void> {
+  const metadata = resource.metadata ??= {};
+  const labels = metadata.labels ??= {};
+
+  labels[PROMOTE_LABEL_KEY] = 'true';
+
+  await resource.save();
+}
+
+export async function applyWorkloadPolicyLabel(store: any, snapshot: ProposalSnapshot): Promise<void> {
+  const {
+    namespace, name, workloadName, ownerWorkloadSteveType
+  } = snapshot;
+
+  if (!namespace || !name || !workloadName || !ownerWorkloadSteveType) {
+    return;
+  }
+
+  const workload = await store.dispatch('cluster/find', {
+    type: ownerWorkloadSteveType,
+    id:   `${ namespace }/${ workloadName }`,
+  });
+
+  if (!workload) {
+    return;
+  }
+
+  // CronJob nests its pod template under spec.jobTemplate.spec.template; every other
+  // workload type (Deployment/StatefulSet/DaemonSet/Job) exposes it directly at spec.template.
+  const podTemplate = workload.spec?.jobTemplate?.spec?.template ?? workload.spec?.template;
+
+  if (!podTemplate) {
+    return;
+  }
+
+  const metadata = podTemplate.metadata ??= {};
+  const labels = metadata.labels ??= {};
+
+  labels[POLICY_LABEL_KEY] = name;
+
+  await workload.save();
+}
+
+export async function watchAndApplyProtectMode(
+  store: any,
+  snapshot: ProposalSnapshot,
+  timeoutMs: number = PROMOTE_WATCH_TIMEOUT_MS
+): Promise<void> {
+  const { namespace, name } = snapshot;
+
+  if (!namespace || !name) {
+    return;
+  }
+
+  const policyId = `${ namespace }/${ name }`;
+
+  await store.dispatch('cluster/findAll', { type: RESOURCE.ACTIVE_POLICIES, opt: { watch: true } });
+
+  try {
+    await waitFor(() => !!store.getters['cluster/byId'](RESOURCE.ACTIVE_POLICIES, policyId), `policy ${ policyId } to be created`, timeoutMs);
+  } catch {
+    return;
+  }
+
+  const policy = store.getters['cluster/byId'](RESOURCE.ACTIVE_POLICIES, policyId);
+
+  if (!policy) {
+    return;
+  }
+
+  policy.spec = policy.spec || {};
+  policy.spec.mode = POLICY_MODE.PROTECT;
+
+  await policy.save();
+}
+
+/**
+ * Kicks off the two independent background follow-up actions for a single promoted proposal.
+ * Fire-and-forget from the caller's perspective - errors are intentionally swallowed since
+ * there's no UI left listening by the time these settle.
+ */
+export function runPromoteFollowUps(store: any, snapshot: ProposalSnapshot, { targetMode, autoApply }: PromoteOptions): void {
+  if (autoApply) {
+    applyWorkloadPolicyLabel(store, snapshot).catch(() => {});
+  }
+
+  if (targetMode === POLICY_MODE.PROTECT) {
+    watchAndApplyProtectMode(store, snapshot).catch(() => {});
+  }
+}


### PR DESCRIPTION
## Description

Implements the Policy Proposals Promotion modal, allowing a proposal to be promoted to an active policy (single or bulk), with a follow-up "Apply Mode" step (automatic vs. manual).

Fix #631 

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

Verify:

- Promote (single + bulk) from the Policy Proposals list/detail page opens the modal, walks through the Apply Mode step, and completes successfully.


## Additional Information

### Tradeoff

This implementation applies the `security.rancher.io/promote` label to trigger promotion, which is the correct/intended mechanism. However, the backend hasn't yet released a build with the watcher update that handles this label (still uses outdated `security.rancher.io/policy-ready`), so promotion is currently non-functional end-to-end pending an updated build.

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
