### PR TITLE
#671 Runtime Enforcer: Active policy detail page (Title bar and Metadata with tabs); #678 Get image name in policy proposals list page; #665 Fix the authentication error when adding repositories in the Rancher Prime during installation 

### DIFF
--- a/pkg/common/components/ExpandableDescription.vue
+++ b/pkg/common/components/ExpandableDescription.vue
@@ -1,0 +1,120 @@
+<script>
+export default {
+  name: 'ExpandableDescription',
+  props: {
+    text: {
+      type: String,
+      required: true,
+      default: ''
+    },
+    lines: {
+      type: Number,
+      default: 3
+    }
+  },
+  data() {
+    return {
+      isExpanded: false,
+      isTruncatable: false,
+    };
+  },
+  watch: {
+    text() {
+      this.checkTruncation();
+    }
+  },
+  mounted() {
+    this.checkTruncation();
+    window.addEventListener('resize', this.checkTruncation);
+  },
+  beforeUnmount() {
+    window.removeEventListener('resize', this.checkTruncation);
+  },
+  methods: {
+    checkTruncation() {
+      this.$nextTick(() => {
+        const el = this.$refs.content;
+        if (!el) return;
+
+        // If the total scrollable height is greater than the clamped visible height,
+        // it means the text exceeds the 3-line limit.
+        this.isTruncatable = el.scrollHeight > el.clientHeight;
+      });
+    },
+    expand() {
+      this.isExpanded = true;
+    }
+  }
+};
+</script>
+
+<template>
+  <div class="expandable-description">
+    <div
+        ref="content"
+        class="content-text"
+        :class="{ 'clamped': !isExpanded, 'expanded': isExpanded }"
+        :style="{ '--line-clamp': lines }"
+    >
+      {{ text }}
+    </div>
+
+    <span
+        v-if="!isExpanded && isTruncatable"
+        class="read-more-btn"
+        @click="expand"
+    >
+      {{ t('imageScanner.general.readMore') }}
+    </span>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.expandable-description {
+  position: relative;
+  width: 100%;
+  display: block;
+}
+
+.content-text {
+  color: var(--disabled-text);
+  font-family: 'Lato', sans-serif;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 21px;
+
+  /* Smooth slide-down transition */
+  transition: max-height 0.4s ease-in-out;
+  overflow: hidden;
+
+  &.clamped {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: var(--line-clamp, 3);
+    /* Calculate exact max-height: 21px line-height * 3 lines */
+    max-height: calc(21px * var(--line-clamp, 3));
+  }
+
+  &.expanded {
+    /* Arbitrarily large max-height to allow the slide-down transition to complete */
+    max-height: 2000px;
+  }
+}
+
+.read-more-btn {
+  position: absolute;
+  bottom: 2px;
+  right: 0;
+  color: var(--disabled-text);
+  text-decoration: underline;
+  cursor: pointer;
+
+  /* Use a gradient to fade over the text smoothly, hiding the native CSS ellipsis */
+  background: linear-gradient(to right, transparent, var(--body-bg) 24px, var(--body-bg) 100%);
+  padding-left: 24px;
+
+  &:hover {
+    text-decoration: none;
+  }
+}
+</style>

--- a/pkg/common/components/RancherMetaProperty.vue
+++ b/pkg/common/components/RancherMetaProperty.vue
@@ -35,12 +35,33 @@
         <LiveDate :value="property.value" />
       </div>
     </div>
-    <div v-else-if="property.type === 'tags'" class="tags">
+    <div v-if="property.type === 'tags'" class="tags">
       <div class="tags">
         <div v-for="tag in property.tags" :key="tag" class="tag">
           <span class="tag-text">{{ tag }}</span>
         </div>
       </div>
+    </div>
+    <div v-if="property.type === 'icon'" class="text">
+      <div v-if="property.label" class="label">
+        {{ property.label }}
+      </div>
+      <span
+        v-if="property.value"
+        class="icon-text-wrap"
+      >
+        <img
+          v-if="property.imgSrc"
+          :src="property.imgSrc"
+          alt=""
+          width="16"
+          height="16"
+          class="mode-icon"
+        >
+        <span class="mode-text" :class="property.value.toLowerCase()">
+          {{ property.value }}
+        </span>
+      </span>
     </div>
   </div>
 </template>
@@ -67,7 +88,7 @@ export default {
     padding-right: 16px;
     flex: 1 0 0;
     break-inside: avoid;
-    margin-bottom: 8px;
+    margin-bottom: 4px;
   }
 
   .text {
@@ -81,7 +102,7 @@ export default {
     font-size: 14px;
     font-style: normal;
     font-weight: 400;
-    // line-height: 21px; /* 150% */
+    line-height: 21px; /* 150% */
 
     .label {
       display: flex;
@@ -143,6 +164,33 @@ export default {
         font-weight: 400;
         line-height: 22px; /* 169.231% */
       }
+    }
+  }
+
+  .icon-text-wrap {
+    display: inline-flex;
+    align-items: center;
+    flex-wrap: nowrap;
+    white-space: nowrap;
+  }
+
+  .mode-icon {
+    margin-right: 8px;
+  }
+
+  .mode-text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-family: Lato;
+    font-size: 14px;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 21px; /* 150% */
+    &.monitor {
+      color: #1F67DB;
+    }
+    &.protect {
+      color: #007032;
     }
   }
 </style>

--- a/pkg/common/types.ts
+++ b/pkg/common/types.ts
@@ -1,7 +1,8 @@
 export interface MetadataProperty {
-  type: 'text' | 'tags' | 'link' | 'route' | 'date';
+  type: 'text' | 'tags' | 'link' | 'route' | 'date' | 'icon';
   label?: string;
   value?: string;
   tags?: string[];
   route?: object;
+  imgSrc?: string;
 }

--- a/pkg/runtime-enforcer/components/InstallView.vue
+++ b/pkg/runtime-enforcer/components/InstallView.vue
@@ -918,10 +918,10 @@ onMounted(async() => {
               data-testid="appco-secret"
               :register-before-hook="registerSecretHook"
               :limit-to-namespace="false"
-              :namespace="'default'"
+              :namespace="'cattle-system'"
               :in-store="inStore"
               :allow-ssh="false"
-              generate-name="appco-auth-"
+              generate-name="clusterrepo-appco-auth-"
               :cache-secrets="true"
               @inputauthval="onAuthInputChange"
             />

--- a/pkg/runtime-enforcer/components/common/StatusBadge.vue
+++ b/pkg/runtime-enforcer/components/common/StatusBadge.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="badge"
+    class="badge badge-ss"
     :class="statusClass"
   >
     <div
@@ -16,6 +16,7 @@
         {{ t(`runtimeEnforcer.activePolicies.status.${status.toLowerCase()}`) }}
       </div>
       <div
+        v-if="nodesInfo && Object.keys(nodesInfo).length > 0"
         class="message-hover-overlay"
         :class="{ 'show-top': showOnTop }"
       >
@@ -84,7 +85,9 @@ export default {
 
 <style lang="scss" scoped>
   @import '../../styles/_variables.scss';
-
+  .badge-ss {
+    line-height: 0;
+  }
   .badge {
     /* layout */
     display: inline-block;

--- a/pkg/runtime-enforcer/config/policy-proposals-table.ts
+++ b/pkg/runtime-enforcer/config/policy-proposals-table.ts
@@ -192,15 +192,15 @@ export function getActivePoliciesHeaders() {
     {
       name:     'violations',
       labelKey: 'runtimeEnforcer.activePolicies.columns.violations',
-      value:    'violationCount',
-      sort:     'violationCount',
+      value:    'activeViolationCount',
+      sort:     'activeViolationCount',
       width:    FIGMA_COLUMN_WIDTH.violations,
     },
     {
       name:     'occurrences',
       labelKey: 'runtimeEnforcer.activePolicies.columns.occurrences',
-      value:    'status.observedGeneration',
-      sort:     'status.observedGeneration',
+      value:    'violationCount',
+      sort:     'violationCount',
       width:    FIGMA_COLUMN_WIDTH.occurrences,
     },
   ];

--- a/pkg/runtime-enforcer/detail/security.rancher.io.workloadpolicy.vue
+++ b/pkg/runtime-enforcer/detail/security.rancher.io.workloadpolicy.vue
@@ -26,11 +26,7 @@ const store = useStore();
 const route = useRoute();
 const i18n = useI18n(store);
 
-const canEdit = computed(async () => {
-  const policyEntry = await store.dispatch('cluster/find', { type: RESOURCE.ACTIVE_POLICIES, id: policy.id});
-
-  return policyEntry?.canEdit;
-});
+const canUpdate = computed(() => policy.canUpdate);
 
 const ownerWorkload = ref<any>(null);
 
@@ -145,7 +141,7 @@ const metaProperties = computed<MetadataProperty[]>(() => [
         </div>
         <div class="resource-header-actions">
           <RcButton
-            v-if="canEdit"
+            v-if="canUpdate"
             variant="primary"
             left-icon="refresh"
             size="large"

--- a/pkg/runtime-enforcer/detail/security.rancher.io.workloadpolicy.vue
+++ b/pkg/runtime-enforcer/detail/security.rancher.io.workloadpolicy.vue
@@ -1,0 +1,289 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import { useRoute } from 'vue-router';
+import { useStore } from 'vuex';
+import DetailPage from '@shell/components/Resource/Detail/Page.vue';
+import RcButton from '@components/RcButton/RcButton.vue';
+import { useI18n } from '@shell/composables/useI18n';
+import { NAMESPACE } from '@shell/config/types';
+import RancherMeta from '@common/components/RancherMeta.vue';
+import { MetadataProperty } from '@common/types';
+import ResourceTabs from '@shell/components/form/ResourceTabs';
+import Tab from '@shell/components/Tabbed/Tab';
+import { PRODUCT_NAME, RESOURCE } from '@runtime-enforcer/types';
+import ActionMenu from '@shell/components/ActionMenuShell.vue';
+import StatusBadge from '@runtime-enforcer/components/common/StatusBadge.vue';
+import ExpandableDescription from '@common/components/ExpandableDescription.vue';
+
+
+const props = defineProps<{
+  value: any;
+}>();
+
+const policy = props.value;
+
+const store = useStore();
+const route = useRoute();
+const i18n = useI18n(store);
+
+const canEdit = computed(async () => {
+  const policyEntry = await store.dispatch('cluster/find', { type: RESOURCE.ACTIVE_POLICIES, id: policy.id});
+
+  return policyEntry?.canEdit;
+});
+
+const ownerWorkload = ref<any>(null);
+
+onMounted(async() => {
+  //ToDo: Prepare to get wroklaod info from backend data
+});
+
+const namespaceRoute = computed(() => ({
+  name:   'c-cluster-product-resource-id',
+  params: {
+    product:  'explorer',
+    cluster:  route.params.cluster,
+    resource: NAMESPACE,
+    id:       policy.metadata?.namespace,
+  },
+}));
+
+const modetext = computed(() => {
+  return i18n.t(`runtimeEnforcer.activePolicies.mode.${policy.spec.mode.toLowerCase()}`);
+});
+
+const modeIconImgSrc = computed(() => {
+  if (policy.spec.mode === 'monitor') {
+    return require('@runtime-enforcer/assets/img/monitor.svg');
+  } else if (policy.spec.mode === 'protect') {
+    return require('@runtime-enforcer/assets/img/protect.svg');
+  } else if (policy.spec.mode === 'enforce') {
+    return null;
+  }
+});
+
+const metaProperties = computed<MetadataProperty[]>(() => [
+  {
+    type:  'route',
+    label: i18n.t('runtimeEnforcer.activePolicy.masthead.namespace'),
+    value: policy.metadata?.namespace,
+    route: namespaceRoute.value,
+  },
+  {
+    type:  ownerWorkload.value ? 'route' : 'text',
+    label: i18n.t('runtimeEnforcer.activePolicy.masthead.workload'),
+    value: '',//policy.workload,
+    route: ownerWorkload.value?.detailLocation,
+  },
+  {
+    type:  'text',
+    label: i18n.t('runtimeEnforcer.activePolicy.masthead.workloadType'),
+    value: '',//policy.workloadType,
+  },
+  {
+    type:  'icon',
+    label: i18n.t('runtimeEnforcer.activePolicy.masthead.mode'),
+    value: modetext.value,
+    imgSrc: modeIconImgSrc.value,
+  },
+  {
+    type:  'text',
+    label: i18n.t('runtimeEnforcer.activePolicy.masthead.violations'),
+    value: `${ policy.activeViolationCount }`,
+  },
+  {
+    type:  'text',
+    label: i18n.t('runtimeEnforcer.activePolicy.masthead.occurrences'),
+    value: policy.violationCount,
+  },
+  {
+    type:  'text',
+    label: i18n.t('runtimeEnforcer.activePolicy.masthead.nodes'),
+    value: policy.status.totalNodes,
+  },
+  {
+    type:  'text',
+    label: i18n.t('runtimeEnforcer.activePolicy.masthead.executables'),
+    value: policy.executables.length,
+  },
+  {
+    type:  'date',
+    label: i18n.t('runtimeEnforcer.activePolicy.masthead.age'),
+    value: policy.metadata?.creationTimestamp,
+  },
+]);
+</script>
+
+<template>
+  <DetailPage>
+    <template #top-area>
+      <div class="header">
+        <div class="resource-header">
+          <h1
+            class="resource-header-name-state"
+            style="margin-bottom: 4px;"
+          >
+            <RouterLink
+              class="resource-link"
+              :to="`/c/${$route.params.cluster}/${ PRODUCT_NAME }/${RESOURCE.ACTIVE_POLICIES}`"
+            >
+              {{ t('runtimeEnforcer.activePolicy.label') }}:
+            </RouterLink>
+            <span class="resource-header-name">
+              {{ $route.params.id }}
+            </span>
+            <StatusBadge
+              style="margin-left: 12px"
+              :status="policy?.metadata?.state?.name"
+            />
+          </h1>
+          <ExpandableDescription
+              v-if="policy?.description"
+              :text="policy.description"
+              :lines="3"
+          />
+        </div>
+        <div class="resource-header-actions">
+          <RcButton
+            v-if="canEdit"
+            variant="primary"
+            left-icon="refresh"
+            size="large"
+            @click="policy.changeMode()"
+          >
+            {{ i18n.t('runtimeEnforcer.activePolicy.action.changeMode') }}
+          </RcButton>
+          <ActionMenu
+            button-variant="multiAction"
+            :resource="policy"
+            data-testid="masthead-action-menu"
+            :button-aria-label="t('component.resource.detail.titleBar.ariaLabel.actionMenu', { resource: RESOURCE.ACTIVE_POLICIES })"
+          />
+        </div>
+      </div>
+      <RancherMeta :properties="metaProperties"/>
+    </template>
+    <template #bottom-area>
+     <ResourceTabs
+      :value="policy"
+      mode="view"
+      :need-related="false"
+      :needEvents="false"
+      @update:value="$emit('input', $event)"
+    >
+      <Tab
+        name="nodesEnforcement"
+        :weight="30"
+        :label="t('runtimeEnforcer.activePolicy.tabs.nodesEnforcement')"
+      >
+      </Tab>
+      <Tab
+        name="allowedExecutables"
+        :weight="20"
+        :label="t('runtimeEnforcer.activePolicy.tabs.allowedExecutables')"
+      >
+      </Tab>
+      <Tab
+        name="violations"
+        :weight="20"
+        :label="t('runtimeEnforcer.activePolicy.tabs.violations')"
+      >
+      </Tab>
+    </ResourceTabs>
+    </template>
+  </DetailPage>
+</template>
+
+<style lang="scss" scoped>
+.executable-pill {
+  display: inline-block;
+  padding: 2px 8px;
+  margin: 2px 4px 2px 0;
+  border-radius: 4px;
+  background: var(--tag-bg);
+  color: var(--tag-primary);
+  font-size: 13px;
+}
+.rc-button.variant-multi-action {
+  height: 32px !important;
+}
+:deep(.bottom-area) {
+  margin-top: 0 !important;
+}
+
+.header {
+      /* layout */
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 24px;
+      align-self: stretch;
+      /* style */
+      border-radius: 6px;
+      min-width: 740px;
+      padding-top: 10px;
+
+      .resource-header {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: flex-start;
+        gap: 4px;
+        flex: 1 0 0;
+        max-width: calc(100% - 350px);
+
+        .resource-header-name-state {
+          display: flex;
+          align-items: center;
+          max-width: 100%;
+
+          .resource-header-name {
+            display: inline-block;
+            flex: 1;
+            white-space: nowrap;
+            overflow-x: hidden;
+            overflow-y: clip;
+            text-overflow: ellipsis;
+            margin-left: 4px;
+          }
+        }
+
+        .resource-header-description {
+          /* layout */
+          display: flex;
+          max-width: 900px;
+          height: 21px;
+          flex-direction: column;
+          justify-content: center;
+          /* typography */
+          overflow: hidden;
+          color: var(--disabled-text);
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          font-family: Lato;
+          font-size: 14px;
+          font-style: normal;
+          font-weight: 400;
+          line-height: 21px; /* 150% */
+        }
+      }
+
+      .resource-header-actions {
+        display: flex;
+        align-items: center;
+        gap: 16px;
+
+        &:deep() button[data-testid="masthead-action-menu"] {
+          border-radius: 4px;
+          width: 35px;
+          height: 40px;
+
+          display: inline-flex;
+          flex-direction: row;
+          justify-content: center;
+          align-items: center;
+        }
+      }
+    }
+
+</style>

--- a/pkg/runtime-enforcer/detail/security.rancher.io.workloadpolicyproposal.vue
+++ b/pkg/runtime-enforcer/detail/security.rancher.io.workloadpolicyproposal.vue
@@ -157,15 +157,15 @@ const containerHeaders = computed(() => [
         <template #additional-actions>
           <RcButton
             variant="primary"
-            size="large"
             left-icon="upgrade-alt"
+            size="large"
             @click="proposal.promote()"
           >
             {{ i18n.t('runtimeEnforcer.policyProposal.action.promote') }}
           </RcButton>
         </template>
       </TitleBar>
-      <RancherMeta :properties="metaProperties" />
+      <RancherMeta :properties="metaProperties"/>
     </template>
     <template #bottom-area>
       <h3 class="mmb-6">
@@ -210,5 +210,8 @@ const containerHeaders = computed(() => [
   background: var(--tag-bg);
   color: var(--tag-primary);
   font-size: 13px;
+}
+:deep(.top-area) {
+  border-bottom: dashed var(--border-width) var(--input-border);
 }
 </style>

--- a/pkg/runtime-enforcer/dialog/DeleteActivePoliciesDialog.vue
+++ b/pkg/runtime-enforcer/dialog/DeleteActivePoliciesDialog.vue
@@ -189,33 +189,38 @@ export default {
           name="workloadRemovalOptions"
           data-testid="workload-removal-radio"
         />
-      <span
-        class="confirm-text"
+      <div
+        v-if="workloadRemovalOption === 'manual'"
+        class="mb-16"
       >
-        {{ t(`runtimeEnforcer.activePolicies.deleteDialog.manualRemoval.${ this.isBulk ? 'bulk' : 'single' }`) }}
-        <a
-          :href="DOCUMENTATION_URL"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="doc-link"
+        <span
+          class="confirm-text"
         >
-          {{ t('runtimeEnforcer.activePolicies.deleteDialog.learnMore') }}
-        </a>
-      </span>
-      <div class="tag-group">
-        <div
-          v-for="resource in resources"
-          :key="resource.metadata.uid"
-          class="mt-2"
-        >
-          <RcTag
-            :type="type"
-            class="tag-row"
-            :highlight="false"
+          {{ t(`runtimeEnforcer.activePolicies.deleteDialog.manualRemoval.${ this.isBulk ? 'bulk' : 'single' }`) }}
+          <a
+            :href="DOCUMENTATION_URL"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="doc-link"
           >
-            <div class="tag-data">{{WORKLOAD_PREFIX}} {{ resource.metadata.name }}</div>
-          </RcTag>
-          <CopyToClipboard class="cp-board" :value="`${ WORKLOAD_PREFIX } ${ resource.metadata.name }`" />
+            {{ t('runtimeEnforcer.activePolicies.deleteDialog.learnMore') }}
+          </a>
+        </span>
+        <div class="tag-group">
+          <div
+            v-for="resource in resources"
+            :key="resource.metadata.uid"
+            class="mt-2"
+          >
+            <RcTag
+              :type="type"
+              class="tag-row"
+              :highlight="false"
+            >
+              <div class="tag-data">{{WORKLOAD_PREFIX}} {{ resource.metadata.name }}</div>
+            </RcTag>
+            <CopyToClipboard class="cp-board" :value="`${ WORKLOAD_PREFIX } ${ resource.metadata.name }`" />
+          </div>
         </div>
       </div>
     </template>

--- a/pkg/runtime-enforcer/dialog/DeletePolicyProposalsDialog.vue
+++ b/pkg/runtime-enforcer/dialog/DeletePolicyProposalsDialog.vue
@@ -56,7 +56,7 @@ export default {
     growlMessage() {
       return this.isBulk
         ? this.t('runtimeEnforcer.policyProposal.deleteDialog.growl.bulk', { count: this.resources.length })
-        : this.t('runtimeEnforcer.policyProposal.deleteDialog.growl.single');
+        : this.t('runtimeEnforcer.policyProposal.deleteDialog.growl.single', { name: this.resources[0]?.nameDisplay });
     },
 
     growlTitle() {

--- a/pkg/runtime-enforcer/l10n/en-us.yaml
+++ b/pkg/runtime-enforcer/l10n/en-us.yaml
@@ -151,7 +151,7 @@ runtimeEnforcer:
         title:
           single: '{name} has been deleted'
           bulk: Selected policy proposals ({count}) have been deleted
-        single: The policy proposal has been successfully deleted. Restarting the corresponding workload might take a few minutes to complete.
+        single: The policy proposal {name} has been successfully deleted. Restarting the corresponding workload might take a few minutes to complete.
         bulk: The selected policy proposals ({count}) have been successfully deleted. Restarting the corresponding workloads might take a few minutes to complete.
     promoteDialog:
       title:
@@ -302,7 +302,7 @@ runtimeEnforcer:
           single: '{name} has been deleted'
           bulk: Selected active policies ({count}) have been deleted
         delete:
-          single: The{name} active policy has been successfully deleted.
+          single: The {name} active policy has been successfully deleted.
           bulk: The selected active policies ({count}) have been successfully deleted.
         autoRemoval:
           single: Restarting the corresponding workload might take a few minutes to complete.
@@ -327,3 +327,35 @@ runtimeEnforcer:
       confirm:
         single: 'Are you sure you want to export the <b>{name}</b> active policy? If so, please select the target mode below.'
         bulk: 'Are you sure you want to export the <b>selected active policies ({count})</b>? If so, please select the target mode below.'
+  activePolicy:
+    label: Active Policy
+    policyName: Policy Name
+    description: Description
+    descriptionPlaceholder: Any text you want that better describes this configuration
+    containerName: Container Name
+    allowedExecutables: Allowed Executables
+    executablePlaceholder: /usr/bin/executable
+    addExecutable: Add Executable
+    action:
+      changeMode: Change Mode
+      editPolicy: Edit Policy
+      export: Export
+      delete: Delete
+    badges:
+      learned: Learned
+      manualEntry: Manual Entry
+    masthead:
+      namespace: Namespace
+      workload: Workload
+      workloadType: Workload Type
+      containers: Containers
+      executables: Executables
+      mode: Mode
+      violations: Violations
+      occurrences: Occurrences
+      nodes: Nodes
+      age: Age
+    tabs:
+      nodesEnforcement: Nodes Enforcement
+      allowedExecutables: Allowed Executables
+      violations: Violations

--- a/pkg/runtime-enforcer/list/__tests__/security.rancher.io.workloadpolicyproposal.spec.ts
+++ b/pkg/runtime-enforcer/list/__tests__/security.rancher.io.workloadpolicyproposal.spec.ts
@@ -21,6 +21,10 @@ jest.mock('@shell/config/types', () => ({
     DEPLOYMENT: 'Deployment',
     DAEMON_SET: 'DaemonSet',
   },
+  WORKLOAD_KIND_TO_TYPE_MAPPING: {
+    Deployment: 'apps.deployment',
+    CronJob:    'batch.cronjob',
+  },
 }));
 
 jest.mock('@components/Banner/Banner.vue', () => ({
@@ -58,6 +62,13 @@ jest.mock('@components/RcButton/RcButton.vue', () => ({
 }));
 
 jest.mock('@shell/types/store/pagination.types', () => ({
+  FilterArgs: class FilterArgs {
+    filters: unknown[];
+
+    constructor(input: { filters: unknown[] }) {
+      this.filters = input.filters;
+    }
+  },
   PaginationFilterField: class PaginationFilterField {
     field: string;
     value: string;
@@ -281,5 +292,96 @@ describe('security.rancher.io.workloadpolicyproposal list', () => {
       resources:  selected,
       modalWidth: '640',
     });
+  });
+
+  it('does not open promote modal when no selected rows', () => {
+    const wrapper = makeWrapper({ canCreate: false });
+
+    (wrapper.vm as any).selectedRows = [];
+    (wrapper.vm as any).promoteSelected();
+
+    expect(mockStoreDispatch).not.toHaveBeenCalled();
+  });
+
+  it('opens promote modal with selected rows', () => {
+    const wrapper = makeWrapper({ canCreate: false });
+    const selected = [{ metadata: { name: 'policy-a' } }];
+
+    (wrapper.vm as any).selectedRows = selected;
+    (wrapper.vm as any).promoteSelected();
+
+    expect(mockStoreDispatch).toHaveBeenCalledWith('cluster/promptModal', {
+      component:  'PromotePolicyDialog',
+      resources:  selected,
+      modalWidth: '640',
+    });
+  });
+
+  it('does not open delete modal when no selected rows', () => {
+    const wrapper = makeWrapper({ canCreate: false });
+
+    (wrapper.vm as any).selectedRows = [];
+    (wrapper.vm as any).deleteSelected();
+
+    expect(mockStoreDispatch).not.toHaveBeenCalled();
+  });
+
+  it('opens delete modal with selected rows', () => {
+    const wrapper = makeWrapper({ canCreate: false });
+    const selected = [{ metadata: { name: 'policy-a' } }];
+
+    (wrapper.vm as any).selectedRows = selected;
+    (wrapper.vm as any).deleteSelected();
+
+    expect(mockStoreDispatch).toHaveBeenCalledWith('cluster/promptModal', {
+      component:  'DeletePolicyProposalsDialog',
+      resources:  selected,
+      modalWidth: '640',
+    });
+  });
+
+  it('skips fetching secondary resources when pagination is enabled', async() => {
+    const wrapper = makeWrapper({ canCreate: false });
+
+    const result = await (wrapper.vm as any).fetchSecondaryResources({ canPaginate: true });
+
+    expect(result).toBeUndefined();
+    expect(mockStoreDispatch).not.toHaveBeenCalled();
+  });
+
+  it('fetches all workload resources when pagination is disabled', async() => {
+    const wrapper = makeWrapper({ canCreate: false });
+
+    await (wrapper.vm as any).fetchSecondaryResources({ canPaginate: false });
+
+    expect(mockStoreDispatch).toHaveBeenCalledWith('cluster/findAll', { type: 'apps.deployment' });
+    expect(mockStoreDispatch).toHaveBeenCalledWith('cluster/findAll', { type: 'batch.cronjob' });
+  });
+
+  it('fetches a single page of workload resources for the current owner kind', async() => {
+    const wrapper = makeWrapper({ canCreate: false });
+    const page = [{ metadata: { namespace: 'team-a', name: 'nginx', ownerReferences: [{ kind: 'Deployment' }] } }];
+
+    mockStoreDispatch.mockResolvedValueOnce([{ metadata: { name: 'nginx' } }]);
+
+    const result = await (wrapper.vm as any).fetchPageSecondaryResources({ force: false, page });
+
+    expect(mockStoreDispatch).toHaveBeenCalledWith('cluster/findPage', {
+      type: 'apps.deployment',
+      opt:  expect.objectContaining({
+        force: false,
+        pagination: expect.anything(),
+      }),
+    });
+    expect(result).toEqual([{ metadata: { name: 'nginx' } }]);
+  });
+
+  it('returns early when no page rows are provided', async() => {
+    const wrapper = makeWrapper({ canCreate: false });
+
+    const result = await (wrapper.vm as any).fetchPageSecondaryResources({ force: false, page: [] });
+
+    expect(result).toBeUndefined();
+    expect(mockStoreDispatch).not.toHaveBeenCalled();
   });
 });

--- a/pkg/runtime-enforcer/list/security.rancher.io.workloadpolicy.vue
+++ b/pkg/runtime-enforcer/list/security.rancher.io.workloadpolicy.vue
@@ -215,7 +215,7 @@ function changeModeSelected() {
 </script>
 
 <template>
-  <div class="policy-proposals-page">
+  <div class="active-policies-page">
 
     <Banner
       color="info"
@@ -346,7 +346,7 @@ function changeModeSelected() {
 </template>
 
 <style scoped lang="scss">
-  .policy-proposals-page {
+  .active-policies-page {
     display: flex;
     flex-direction: column;
     gap: 24px;

--- a/pkg/runtime-enforcer/list/security.rancher.io.workloadpolicyproposal.vue
+++ b/pkg/runtime-enforcer/list/security.rancher.io.workloadpolicyproposal.vue
@@ -10,9 +10,10 @@ import { DOCUMENTATION_URL, RESOURCE, type WorkloadPolicyProposal } from '@runti
 import { getPolicyProposalHeaders, getContainerTableHeaders } from '@runtime-enforcer/config/policy-proposals-table';
 import RcButton from '@components/RcButton/RcButton.vue';
 import _ from 'lodash';
-import { PaginationFilterField, PaginationParamFilter } from '@shell/types/store/pagination.types';
 import { WORKLOAD_KINDS } from '@shell/config/types';
 import SortableTable from '@shell/components/SortableTable';
+import { WORKLOAD_KIND_TO_TYPE_MAPPING } from '@shell/config/types';
+import { FilterArgs, PaginationFilterField, PaginationParamFilter } from '@shell/types/store/pagination.types';
 
 const store = useStore();
 
@@ -183,6 +184,38 @@ function deleteSelected() {
     modalWidth: '640',
   });
 }
+
+async function fetchSecondaryResources({ canPaginate }: { canPaginate: boolean }) {
+  if (canPaginate) {
+    return;
+  }
+
+  return await Promise.all(
+    Object.values(WORKLOAD_KIND_TO_TYPE_MAPPING).map((workloadType) =>
+      store.dispatch(`cluster/findAll`, { type: workloadType })
+    )
+  );
+}
+
+async function fetchPageSecondaryResources({ force, page }: { force: any; page: any[] }) {
+  if (!page?.length) {
+    return;
+  }
+
+  const opt = {
+    force,
+    pagination: new FilterArgs({
+      filters: PaginationParamFilter.createMultipleFields(page.map((r: any) => new PaginationFilterField({
+        field: 'id',
+        value: `${ r.metadata.namespace }/${ r.metadata.name }`
+      }))),
+    })
+  };
+  const workloadResource = WORKLOAD_KIND_TO_TYPE_MAPPING[page[0]?.metadata?.ownerReferences?.[0]?.kind];
+  const workload = await store.dispatch(`cluster/findPage`, { type: workloadResource, opt });
+
+  return workload;
+}
 </script>
 
 <template>
@@ -256,6 +289,8 @@ function deleteSelected() {
       :key-field="'id'"
       :local-filter="filterRowsLocal"
       :api-filter="filterRowsApi"
+      :fetch-secondary-resources="fetchSecondaryResources"
+      :fetch-page-secondary-resources="fetchPageSecondaryResources"
       :use-query-params-for-simple-filtering="useQueryParamsForSimpleFiltering"
       @selection="onSelectionChange"
     >

--- a/pkg/runtime-enforcer/models/__tests__/security.rancher.io.workloadpolicyproposal.spec.ts
+++ b/pkg/runtime-enforcer/models/__tests__/security.rancher.io.workloadpolicyproposal.spec.ts
@@ -212,6 +212,90 @@ describe('WorkloadPolicyProposal model', () => {
     });
   });
 
+  describe('childrenRec', () => {
+    it('builds child rows from the workload template containers when available', () => {
+      proposal.metadata = { namespace: 'team-a', name: 'proposal-1', ownerReferences: [{ name: 'nginx', kind: 'Deployment' }] };
+      proposal.spec = {
+        rulesByContainer: {
+          web: { executables: { allowed: ['/usr/bin/nginx'] } },
+          sidecar: { executables: { allowed: ['/usr/bin/agent', '/usr/bin/metrics'] } },
+        },
+      };
+      proposal.$getters = {
+        all: jest.fn().mockReturnValue([
+          {
+            metadata: { namespace: 'team-a', name: 'nginx' },
+            spec:     {
+              template: {
+                spec: {
+                  containers: [
+                    { name: 'web', image: 'nginx:1.25' },
+                    { name: 'sidecar', image: 'busybox:1.36' },
+                  ],
+                },
+              },
+            },
+          },
+        ]),
+      };
+
+      const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+      const children = proposal.childrenRec;
+
+      expect(children).toEqual([
+        { container: 'web', image: 'nginx:1.25', executableCount: 1, executables: ['/usr/bin/nginx'] },
+        { container: 'sidecar', image: 'busybox:1.36', executableCount: 2, executables: ['/usr/bin/agent', '/usr/bin/metrics'] },
+      ]);
+      expect(logSpy).toHaveBeenCalledWith('image', expect.objectContaining({ web: 'nginx:1.25', sidecar: 'busybox:1.36' }), proposal.rulesByContainer);
+      logSpy.mockRestore();
+    });
+
+    it('uses job template containers when the workload is a job-based resource', () => {
+      proposal.metadata = { namespace: 'team-a', name: 'proposal-2', ownerReferences: [{ name: 'backup', kind: 'CronJob' }] };
+      proposal.spec = {
+        rulesByContainer: {
+          worker: { executables: { allowed: ['/usr/bin/worker'] } },
+        },
+      };
+      proposal.$getters = {
+        all: jest.fn().mockReturnValue([
+          {
+            metadata: { namespace: 'team-a', name: 'backup' },
+            spec:     {
+              jobTemplate: {
+                spec: {
+                  template: {
+                    spec: {
+                      containers: [{ name: 'worker', image: 'repo/worker:v2' }],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ]),
+      };
+
+      expect(proposal.childrenRec).toEqual([
+        { container: 'worker', image: 'repo/worker:v2', executableCount: 1, executables: ['/usr/bin/worker'] },
+      ]);
+    });
+
+    it('falls back to empty images when the owner workload cannot be resolved', () => {
+      proposal.metadata = { namespace: 'team-a', name: 'proposal-3', ownerReferences: [{ name: 'missing', kind: 'Deployment' }] };
+      proposal.spec = {
+        rulesByContainer: {
+          web: { executables: { allowed: ['/usr/bin/nginx'] } },
+        },
+      };
+      proposal.$getters = { all: jest.fn().mockReturnValue([]) };
+
+      expect(proposal.childrenRec).toEqual([
+        { container: 'web', image: '', executableCount: 1, executables: ['/usr/bin/nginx'] },
+      ]);
+    });
+  });
+
   describe('editPolicy / exportPolicy / promote', () => {
     it('editPolicy() does not throw', () => {
       proposal.detailLocation = { query: {} };

--- a/pkg/runtime-enforcer/models/security.rancher.io.workloadpolicy.js
+++ b/pkg/runtime-enforcer/models/security.rancher.io.workloadpolicy.js
@@ -43,6 +43,16 @@ export default class WorkloadPolicyProposal extends SteveModel {
         return action;
       });
 
+    const deleteIndex = out.findIndex((action) => action.action === 'removeProposal');
+
+    if (deleteIndex > -1) {
+      out.splice(deleteIndex, 0, { divider: true });
+    }
+
+    if (this.$rootState.targetRoute && this.$rootState.targetRoute.params && 'id' in this.$rootState.targetRoute.params) {
+      return out;
+    }
+
     out.unshift({
       action:  'changeMode',
       label:   this.t('runtimeEnforcer.activePolicies.actions.changeMode'),
@@ -50,19 +60,35 @@ export default class WorkloadPolicyProposal extends SteveModel {
       enabled: true,
     });
 
-
-
-    const deleteIndex = out.findIndex((action) => action.action === 'removeProposal');
-
-    if (deleteIndex > -1) {
-      out.splice(deleteIndex, 0, { divider: true });
-    }
-
     return out;
   }
 
   get violationCount() {
     return this.status?.violationCount || 0;
+  }
+
+  get activeViolationCount() {
+    return this.status?.activeViolationCount || 0;
+  }
+
+  get fullDetailPageOverride() {
+    return true;
+  }
+
+  get disableResourceDetailDrawer() {
+    return true;
+  }
+
+  get executables() {
+    const rulesByContainer = this.spec?.rulesByContainer || {};
+    const executables = [];
+
+    Object.values(rulesByContainer).forEach((container) => {
+      const allowedExecutables = container?.executables?.allowed || [];
+      executables.push(...allowedExecutables);
+    });
+
+    return executables;
   }
 
   changeMode(resources = this) {

--- a/pkg/runtime-enforcer/models/security.rancher.io.workloadpolicyproposal.js
+++ b/pkg/runtime-enforcer/models/security.rancher.io.workloadpolicyproposal.js
@@ -128,14 +128,43 @@ export default class WorkloadPolicyProposal extends SteveModel {
   }
 
   get childrenRec() {
-    return Object.entries(this.rulesByContainer).map(([containerName, containerRules]) => {
-      return {
-        container:       containerName,
-        image:           containerRules?.image || '',
-        executableCount: containerRules?.executables?.allowed?.length || 0,
-        executables:     containerRules?.executables?.allowed || [],
-      };
-    });
+    let ownerWorkload = null;
+    let image = null;
+
+    return (() => {
+      try {
+        ownerWorkload = (this.$getters['all'](this.ownerWorkloadSteveType) || []).find((w) => `${ w.metadata.namespace }/${ w.metadata.name }` === `${ this.metadata?.namespace }/${ this.workload }`);
+        const containers = ownerWorkload.spec?.template?.spec?.containers
+          || ownerWorkload.spec?.jobTemplate?.spec?.template?.spec?.containers
+          || [];
+
+        image = containers.reduce((acc, container) => {
+          acc[container.name] = container.image;
+
+          return acc;
+        }, {});
+
+        console.log('image', image, this.rulesByContainer);
+
+        return Object.entries(this.rulesByContainer).map(([containerName, containerRules]) => {
+          return {
+            container:       containerName,
+            image:           image[containerName] || '',
+            executableCount: containerRules?.executables?.allowed?.length || 0,
+            executables:     containerRules?.executables?.allowed || [],
+          };
+        });
+      } catch {
+        return Object.entries(this.rulesByContainer).map(([containerName, containerRules]) => {
+          return {
+            container:       containerName,
+            image:           '',
+            executableCount: containerRules?.executables?.allowed?.length || 0,
+            executables:     containerRules?.executables?.allowed || [],
+          };
+        });
+      }
+    })();
   }
 
   editPolicy() {

--- a/pkg/vulnerability-scanner/components/CveDetails.vue
+++ b/pkg/vulnerability-scanner/components/CveDetails.vue
@@ -4,7 +4,7 @@ import { BadgeState } from '@components/BadgeState';
 import { PRODUCT_NAME, RESOURCE, PAGE } from '@vulnerability-scanner/types';
 import { NVD_BASE_URL, CVSS_VECTOR_BASE_URL } from '@vulnerability-scanner/constants';
 import { getHighestScore } from '@vulnerability-scanner/utils/report';
-import ExpandableDescription from "@vulnerability-scanner/components/common/ExpandableDescription.vue";
+import ExpandableDescription from "@common/components/ExpandableDescription.vue";
 
 export default {
   name:       'CveDetails',

--- a/pkg/vulnerability-scanner/components/RegistryDetails.vue
+++ b/pkg/vulnerability-scanner/components/RegistryDetails.vue
@@ -63,7 +63,7 @@ import RegistryDetailScanTable from './RegistryDetailScanTable.vue';
 import ScanButton from './common/ScanButton.vue';
 import { getPermissions } from '@vulnerability-scanner/utils/permissions';
 import { trimIntervalSuffix } from '@vulnerability-scanner/utils/app';
-import ExpandableDescription from './common/ExpandableDescription.vue';
+import ExpandableDescription from '@common/components/ExpandableDescription.vue';
 
 export default {
   name:       'RegistryDetails',

--- a/pkg/vulnerability-scanner/components/__tests__/CveDetails.spec.ts
+++ b/pkg/vulnerability-scanner/components/__tests__/CveDetails.spec.ts
@@ -2,7 +2,7 @@ import { jest } from '@jest/globals';
 import { shallowMount, flushPromises } from '@vue/test-utils';
 import CveDetails from '../CveDetails.vue';
 import { BadgeState } from '@components/BadgeState';
-import ExpandableDescription from '../common/ExpandableDescription.vue';
+import ExpandableDescription from '@common/components/ExpandableDescription.vue';
 import { RESOURCE } from '@vulnerability-scanner/types';
 import { NVD_BASE_URL, CVSS_VECTOR_BASE_URL } from '@vulnerability-scanner/constants';
 

--- a/pkg/vulnerability-scanner/components/__tests__/RegistryDetails.spec.ts
+++ b/pkg/vulnerability-scanner/components/__tests__/RegistryDetails.spec.ts
@@ -4,7 +4,7 @@ import ActionMenu from '@shell/components/ActionMenuShell.vue';
 import StatusBadge from '../common/StatusBadge.vue';
 import RegistryDetailScanTable from '../RegistryDetailScanTable.vue';
 import ScanButton from '../common/ScanButton.vue';
-import ExpandableDescription from '../common/ExpandableDescription.vue';
+import ExpandableDescription from '@common/components/ExpandableDescription.vue';
 import { trimIntervalSuffix } from '@vulnerability-scanner/utils/app';
 
 jest.mock('../common/RegistryDetailsMeta.vue', () => ({

--- a/pkg/vulnerability-scanner/components/common/__tests__/ExpandableDescription.spec.ts
+++ b/pkg/vulnerability-scanner/components/common/__tests__/ExpandableDescription.spec.ts
@@ -1,5 +1,5 @@
 import { shallowMount } from '@vue/test-utils';
-import ExpandableDescription from '../ExpandableDescription.vue';
+import ExpandableDescription from '@common/components/ExpandableDescription.vue';
 
 describe('ExpandableDescription.vue', () => {
   let wrapper;


### PR DESCRIPTION


## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

Fix #671  (Including Title bar and Metadata with tabs)
<img width="1477" height="962" alt="Screenshot 2026-07-29 at 9 26 23 PM" src="https://github.com/user-attachments/assets/b7ba732b-8bc4-46d4-a74c-2891b54b48ea" />

Fix #678 
By using secondary data resource in the PaginatedResourceTable for get the dataset from corresponding workload resources and in the model the childrenRec can get from the dataset to dig out the image name
<img width="1244" height="963" alt="Screenshot 2026-07-30 at 2 47 27 PM" src="https://github.com/user-attachments/assets/64abd67d-5a45-4b5a-83a6-b9fe2ec6e1ac" />

Fix #665 
There is not UX change, the change is under hood for the namespace and name prefix of the http secret which is used for adding repositories.


There is a minor fix for proposal detail page. The dash line was added between masthead and the table
<img width="1476" height="962" alt="Screenshot 2026-07-29 at 9 27 49 PM" src="https://github.com/user-attachments/assets/69b9aa94-a703-4ff0-b902-8d3c211ae674" />

There is a minor fix for deleting active policy dialog. Only if the user select manual restart workload, the workload list will show on the dialog
<img width="1476" height="962" alt="Screenshot 2026-07-29 at 9 50 06 PM" src="https://github.com/user-attachments/assets/eac4e41e-d78c-47cd-b53d-8766b861db88" />
<img width="1476" height="961" alt="Screenshot 2026-07-29 at 9 50 17 PM" src="https://github.com/user-attachments/assets/6cd9f3fa-ed99-41e7-bc94-ae0d3e10f0b2" />
<img width="1476" height="964" alt="Screenshot 2026-07-29 at 9 50 23 PM" src="https://github.com/user-attachments/assets/e4675292-ec91-4eaa-a1bd-648e28a8c12e" />



<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Fix #671 
1. Go to Active policy page and click one policy to redirect to detail page
2. Observe titlebar with the parent route link, policy name, state badge and primary action button (Change mode) and the secondary action buttons
3. Observe the metadata's in the masthead, the mode value is with style and icon. (Workload and workload type is not provided from backend, so they are empty so far)

Fix #678 
1. Go to policy proposals list page and expand any row of the proposal
2. Observe the sub-table to verify the image value

Fix #665 
1. Prepare a non-backend environment and go to Runtime Enforcer, it will go to installation page
2. In the 1st step, choose "create a new secret", type in the authentication credential.
3. Click continue button to next step and click to add repositories.
4. Observe the repositories status in Apps > Repositories page, verify that there is no errors
5. Continue to verify  all the installation process until all the backend applications are installed

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
