### PR TITLE
Runtime Enforcer: Active Policy edit page

### DIFF
--- a/pkg/runtime-enforcer/edit/__tests__/security.rancher.io.workloadpolicy.spec.ts
+++ b/pkg/runtime-enforcer/edit/__tests__/security.rancher.io.workloadpolicy.spec.ts
@@ -112,7 +112,7 @@ describe('WorkloadPolicyEdit component', () => {
     expect(wrapper.vm.containerList[0].image).toBe('registry.k8s.io/nginx:v1.0');
   });
 
-  it('falls back to ownerReferences and ownerWorkload when workloadRef is missing or empty', () => {
+  it('returns undefined for workload properties when workloadRef is not present', () => {
     const wrapper = shallowMount(WorkloadPolicyEdit, {
       global: {
         plugins: [store],
@@ -122,12 +122,8 @@ describe('WorkloadPolicyEdit component', () => {
       props: {
         mode:  'edit',
         value: {
-          metadata: {
-            name:            'deploy-nginx-ingress',
-            namespace:       'ingress',
-            ownerReferences: [{ name: 'nginx-deployment', kind: 'Deployment' }],
-          },
-          spec: {
+          metadata: { name: 'deploy-nginx-ingress', namespace: 'ingress' },
+          spec:     {
             mode:             'protect',
             rulesByContainer: {
               nginx: { executables: { allowed: ['/usr/bin/nginx'] } },
@@ -137,19 +133,9 @@ describe('WorkloadPolicyEdit component', () => {
       },
     });
 
-    wrapper.vm.ownerWorkload = {
-      spec: {
-        template: {
-          spec: {
-            containers: [{ name: 'nginx', image: 'nginx:1.25' }],
-          },
-        },
-      },
-    };
-
-    expect(wrapper.vm.workloadName).toBe('nginx-deployment');
-    expect(wrapper.vm.workloadType).toBe('Deployment');
-    expect(wrapper.vm.containerImages).toEqual({ nginx: 'nginx:1.25' });
+    expect(wrapper.vm.workloadName).toBeUndefined();
+    expect(wrapper.vm.workloadType).toBeUndefined();
+    expect(wrapper.vm.containerImages).toBeUndefined();
   });
 
   it('validates form and catches empty or invalid executable paths', () => {

--- a/pkg/runtime-enforcer/edit/__tests__/security.rancher.io.workloadpolicy.spec.ts
+++ b/pkg/runtime-enforcer/edit/__tests__/security.rancher.io.workloadpolicy.spec.ts
@@ -2,8 +2,20 @@ import { shallowMount } from '@vue/test-utils';
 import { createStore } from 'vuex';
 import WorkloadPolicyEdit from '../security.rancher.io.workloadpolicy.vue';
 
+// Mock shell components at module level to avoid runtime defineEmits warnings from uncompiled dependencies
+jest.mock('@shell/components/CruResource', () => ({
+  name: 'CruResource',
+  template: '<div><slot /></div>',
+}));
+
+jest.mock('@shell/components/form/NameNsDescription', () => ({
+  name: 'NameNsDescription',
+  template: '<div></div>',
+}));
+
 describe('WorkloadPolicyEdit component', () => {
   let store: any;
+  let dispatchSpy: jest.SpyInstance;
 
   beforeEach(() => {
     store = createStore({
@@ -13,28 +25,38 @@ describe('WorkloadPolicyEdit component', () => {
         'cluster/schemaFor': () => () => ({ canCreate: true }),
       },
     });
-    store.dispatch = jest.fn().mockResolvedValue({});
+
+    dispatchSpy = jest.spyOn(store, 'dispatch').mockResolvedValue({});
   });
 
-  it('renders the edit form components successfully', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const defaultStubs = {
+    CruResource:       true,
+    NameNsDescription: true,
+    LabeledInput:      true,
+    Tabbed:            true,
+    Tab:               true,
+    Banner:            true,
+    RadioGroup:        true,
+    RancherMeta:       true,
+  };
+
+  const createDefaultMocks = () => ({
+    $store: store,
+    $route: {
+      params: { cluster: 'local' },
+    },
+  });
+
+  it('renders the edit form components successfully and resolves mode', () => {
     const wrapper = shallowMount(WorkloadPolicyEdit, {
       global: {
         plugins: [store],
-        stubs:   {
-          CruResource:       true,
-          NameNsDescription: true,
-          LabeledInput:      true,
-          Tabbed:            true,
-          Tab:               true,
-          Banner:            true,
-          RadioGroup:        true,
-          RancherMeta:       true,
-        },
-        mocks: {
-          $route: {
-            params: { cluster: 'local' }
-          }
-        }
+        stubs:   defaultStubs,
+        mocks:   createDefaultMocks(),
       },
       props: {
         mode:  'edit',
@@ -44,37 +66,98 @@ describe('WorkloadPolicyEdit component', () => {
             mode:             'protect',
             rulesByContainer: {
               'deploy-nginx-ingress': {
-                executables: { allowed: ['/usr/bin/nginx'] }
-              }
-            }
-          }
-        }
-      }
+                executables: { allowed: ['/usr/bin/nginx'] },
+              },
+            },
+          },
+        },
+      },
     });
 
     expect(wrapper.exists()).toBe(true);
     expect(wrapper.vm.spec.mode).toBe('protect');
   });
 
+  it('resolves workloadName, workloadType, and containerImages directly from workloadRef when available', () => {
+    const wrapper = shallowMount(WorkloadPolicyEdit, {
+      global: {
+        plugins: [store],
+        stubs:   defaultStubs,
+        mocks:   createDefaultMocks(),
+      },
+      props: {
+        mode:  'edit',
+        value: {
+          metadata:    { name: 'deploy-nginx-ingress', namespace: 'ingress' },
+          workloadRef: {
+            workloadName: 'nginx-ingress',
+            workloadType: 'Deployment',
+            imageMap:     { 'nginx-ingress': 'registry.k8s.io/nginx:v1.0' },
+          },
+          spec: {
+            mode:             'protect',
+            rulesByContainer: {
+              'nginx-ingress': {
+                executables: { allowed: ['/usr/bin/nginx'] },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(wrapper.vm.workloadName).toBe('nginx-ingress');
+    expect(wrapper.vm.workloadType).toBe('Deployment');
+    expect(wrapper.vm.containerImages).toEqual({ 'nginx-ingress': 'registry.k8s.io/nginx:v1.0' });
+    expect(wrapper.vm.containerList[0].image).toBe('registry.k8s.io/nginx:v1.0');
+  });
+
+  it('falls back to ownerReferences and ownerWorkload when workloadRef is missing or empty', () => {
+    const wrapper = shallowMount(WorkloadPolicyEdit, {
+      global: {
+        plugins: [store],
+        stubs:   defaultStubs,
+        mocks:   createDefaultMocks(),
+      },
+      props: {
+        mode:  'edit',
+        value: {
+          metadata: {
+            name:            'deploy-nginx-ingress',
+            namespace:       'ingress',
+            ownerReferences: [{ name: 'nginx-deployment', kind: 'Deployment' }],
+          },
+          spec: {
+            mode:             'protect',
+            rulesByContainer: {
+              nginx: { executables: { allowed: ['/usr/bin/nginx'] } },
+            },
+          },
+        },
+      },
+    });
+
+    wrapper.vm.ownerWorkload = {
+      spec: {
+        template: {
+          spec: {
+            containers: [{ name: 'nginx', image: 'nginx:1.25' }],
+          },
+        },
+      },
+    };
+
+    expect(wrapper.vm.workloadName).toBe('nginx-deployment');
+    expect(wrapper.vm.workloadType).toBe('Deployment');
+    expect(wrapper.vm.containerImages).toEqual({ nginx: 'nginx:1.25' });
+  });
+
   it('validates form and catches empty or invalid executable paths', () => {
     const wrapper = shallowMount(WorkloadPolicyEdit, {
       global: {
         plugins: [store],
-        stubs:   {
-          CruResource:       true,
-          NameNsDescription: true,
-          LabeledInput:      true,
-          Tabbed:            true,
-          Tab:               true,
-          Banner:            true,
-          RadioGroup:        true,
-          RancherMeta:       true,
-        },
-        mocks: {
-          $route: {
-            params: { cluster: 'local' }
-          }
-        }
+        stubs:   defaultStubs,
+        mocks:   createDefaultMocks(),
       },
       props: {
         mode:  'edit',
@@ -84,15 +167,16 @@ describe('WorkloadPolicyEdit component', () => {
             mode:             'protect',
             rulesByContainer: {
               'deploy-nginx-ingress': {
-                executables: { allowed: [''] }
-              }
-            }
-          }
-        }
-      }
+                executables: { allowed: [''] },
+              },
+            },
+          },
+        },
+      },
     });
 
     const errors = wrapper.vm.validateForm();
+
     expect(errors.length).toBeGreaterThan(0);
   });
 
@@ -100,21 +184,8 @@ describe('WorkloadPolicyEdit component', () => {
     const wrapper = shallowMount(WorkloadPolicyEdit, {
       global: {
         plugins: [store],
-        stubs:   {
-          CruResource:       true,
-          NameNsDescription: true,
-          LabeledInput:      true,
-          Tabbed:            true,
-          Tab:               true,
-          Banner:            true,
-          RadioGroup:        true,
-          RancherMeta:       true,
-        },
-        mocks: {
-          $route: {
-            params: { cluster: 'local' }
-          }
-        }
+        stubs:   defaultStubs,
+        mocks:   createDefaultMocks(),
       },
       props: {
         mode:  'edit',
@@ -124,12 +195,12 @@ describe('WorkloadPolicyEdit component', () => {
             mode:             'protect',
             rulesByContainer: {
               'deploy-nginx-ingress': {
-                executables: { allowed: ['/usr/bin/nginx'] }
-              }
-            }
-          }
-        }
-      }
+                executables: { allowed: ['/usr/bin/nginx'] },
+              },
+            },
+          },
+        },
+      },
     });
 
     wrapper.vm.addExecutable('deploy-nginx-ingress');
@@ -140,5 +211,26 @@ describe('WorkloadPolicyEdit component', () => {
 
     wrapper.vm.updateExecutablePath('deploy-nginx-ingress', 1, '/usr/bin/curl');
     expect(allowed[1]).toBe('/usr/bin/curl');
+  });
+
+  it('dispatches cluster/findAll during fetch to populate Vuex cache', async() => {
+    const wrapper = shallowMount(WorkloadPolicyEdit, {
+      global: {
+        plugins: [store],
+        stubs:   defaultStubs,
+        mocks:   createDefaultMocks(),
+      },
+      props: {
+        mode:  'edit',
+        value: {
+          metadata: { name: 'payments-api-policy', namespace: 'ingress' },
+          spec:     { rulesByContainer: {} },
+        },
+      },
+    });
+
+    await (wrapper.vm as any).$options.fetch.call(wrapper.vm);
+
+    expect(dispatchSpy).toHaveBeenCalledWith('cluster/findAll', expect.objectContaining({ type: expect.any(String) }));
   });
 });

--- a/pkg/runtime-enforcer/edit/__tests__/security.rancher.io.workloadpolicy.spec.ts
+++ b/pkg/runtime-enforcer/edit/__tests__/security.rancher.io.workloadpolicy.spec.ts
@@ -1,0 +1,144 @@
+import { shallowMount } from '@vue/test-utils';
+import { createStore } from 'vuex';
+import WorkloadPolicyEdit from '../security.rancher.io.workloadpolicy.vue';
+
+describe('WorkloadPolicyEdit component', () => {
+  let store: any;
+
+  beforeEach(() => {
+    store = createStore({
+      getters: {
+        'i18n/t':            () => (key: string) => key,
+        'i18n/exists':       () => () => true,
+        'cluster/schemaFor': () => () => ({ canCreate: true }),
+      },
+    });
+    store.dispatch = jest.fn().mockResolvedValue({});
+  });
+
+  it('renders the edit form components successfully', () => {
+    const wrapper = shallowMount(WorkloadPolicyEdit, {
+      global: {
+        plugins: [store],
+        stubs:   {
+          CruResource:       true,
+          NameNsDescription: true,
+          LabeledInput:      true,
+          Tabbed:            true,
+          Tab:               true,
+          Banner:            true,
+          RadioGroup:        true,
+          RancherMeta:       true,
+        },
+        mocks: {
+          $route: {
+            params: { cluster: 'local' }
+          }
+        }
+      },
+      props: {
+        mode:  'edit',
+        value: {
+          metadata: { name: 'payments-api-policy', namespace: 'ingress' },
+          spec:     {
+            mode:             'protect',
+            rulesByContainer: {
+              'deploy-nginx-ingress': {
+                executables: { allowed: ['/usr/bin/nginx'] }
+              }
+            }
+          }
+        }
+      }
+    });
+
+    expect(wrapper.exists()).toBe(true);
+    expect(wrapper.vm.spec.mode).toBe('protect');
+  });
+
+  it('validates form and catches empty or invalid executable paths', () => {
+    const wrapper = shallowMount(WorkloadPolicyEdit, {
+      global: {
+        plugins: [store],
+        stubs:   {
+          CruResource:       true,
+          NameNsDescription: true,
+          LabeledInput:      true,
+          Tabbed:            true,
+          Tab:               true,
+          Banner:            true,
+          RadioGroup:        true,
+          RancherMeta:       true,
+        },
+        mocks: {
+          $route: {
+            params: { cluster: 'local' }
+          }
+        }
+      },
+      props: {
+        mode:  'edit',
+        value: {
+          metadata: { name: 'payments-api-policy', namespace: 'ingress' },
+          spec:     {
+            mode:             'protect',
+            rulesByContainer: {
+              'deploy-nginx-ingress': {
+                executables: { allowed: [''] }
+              }
+            }
+          }
+        }
+      }
+    });
+
+    const errors = wrapper.vm.validateForm();
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('successfully adds and updates executable path entries', () => {
+    const wrapper = shallowMount(WorkloadPolicyEdit, {
+      global: {
+        plugins: [store],
+        stubs:   {
+          CruResource:       true,
+          NameNsDescription: true,
+          LabeledInput:      true,
+          Tabbed:            true,
+          Tab:               true,
+          Banner:            true,
+          RadioGroup:        true,
+          RancherMeta:       true,
+        },
+        mocks: {
+          $route: {
+            params: { cluster: 'local' }
+          }
+        }
+      },
+      props: {
+        mode:  'edit',
+        value: {
+          metadata: { name: 'payments-api-policy', namespace: 'ingress' },
+          spec:     {
+            mode:             'protect',
+            rulesByContainer: {
+              'deploy-nginx-ingress': {
+                executables: { allowed: ['/usr/bin/nginx'] }
+              }
+            }
+          }
+        }
+      }
+    });
+
+    wrapper.vm.addExecutable('deploy-nginx-ingress');
+    const allowed = wrapper.vm.value.spec.rulesByContainer['deploy-nginx-ingress'].executables.allowed;
+
+    expect(allowed).toContain('');
+    expect(allowed.length).toBe(2);
+
+    wrapper.vm.updateExecutablePath('deploy-nginx-ingress', 1, '/usr/bin/curl');
+    expect(allowed[1]).toBe('/usr/bin/curl');
+  });
+});

--- a/pkg/runtime-enforcer/edit/__tests__/security.rancher.io.workloadpolicy.spec.ts
+++ b/pkg/runtime-enforcer/edit/__tests__/security.rancher.io.workloadpolicy.spec.ts
@@ -112,7 +112,7 @@ describe('WorkloadPolicyEdit component', () => {
     expect(wrapper.vm.containerList[0].image).toBe('registry.k8s.io/nginx:v1.0');
   });
 
-  it('returns undefined for workload properties when workloadRef is not present', () => {
+  it('returns empty strings for workload properties when workloadRef is missing or unpopulated', () => {
     const wrapper = shallowMount(WorkloadPolicyEdit, {
       global: {
         plugins: [store],
@@ -133,8 +133,8 @@ describe('WorkloadPolicyEdit component', () => {
       },
     });
 
-    expect(wrapper.vm.workloadName).toBeUndefined();
-    expect(wrapper.vm.workloadType).toBeUndefined();
+    expect(wrapper.vm.workloadName).toBe('');
+    expect(wrapper.vm.workloadType).toBe('');
     expect(wrapper.vm.containerImages).toBeUndefined();
   });
 

--- a/pkg/runtime-enforcer/edit/security.rancher.io.workloadpolicy.vue
+++ b/pkg/runtime-enforcer/edit/security.rancher.io.workloadpolicy.vue
@@ -1,0 +1,458 @@
+<template>
+  <CruResource
+      :mode="mode"
+      :resource="value"
+      :errors="errors"
+      :validation-passed="isValid"
+      :can-yaml="false"
+      @finish="savePolicy"
+      @cancel="cancel"
+  >
+    <div class="active-policy-edit">
+      <Banner
+          v-for="(err, idx) in errors"
+          :key="idx"
+          color="error"
+          :label="err"
+      />
+
+      <NameNsDescription
+          :value="value"
+          :mode="mode"
+          name-label="runtimeEnforcer.activePolicies.columns.policy"
+      />
+
+      <div class="row mb-20">
+        <div class="col span-3">
+          <LabeledInput
+              :value="workloadName"
+              :label="t('runtimeEnforcer.policyProposal.masthead.workload')"
+              :mode="mode"
+              :disabled="true"
+              :required="true"
+          />
+        </div>
+        <div class="col span-3">
+          <LabeledInput
+              :value="workloadType"
+              :label="t('runtimeEnforcer.policyProposal.masthead.workloadType')"
+              :mode="mode"
+              :disabled="true"
+              :required="true"
+          />
+        </div>
+      </div>
+
+      <!-- Mode Selector -->
+      <div class="row mt-20 mb-20">
+        <div class="col span-12">
+          <RadioGroup
+              v-model:value="spec.mode"
+              name="policy-mode"
+              :mode="mode"
+              :options="modeRadioOptions"
+              :row="true"
+          />
+        </div>
+      </div>
+
+      <div class="containers-section mt-30">
+        <div class="containers-title-row mb-15">
+          <h3 class="m-0">
+            {{ t('runtimeEnforcer.policyProposal.containers.title') }}
+          </h3>
+        </div>
+
+        <div class="row">
+          <div class="col span-12">
+            <Tabbed :side-tabs="true">
+              <Tab
+                  v-for="(c, cIdx) in containerList"
+                  :key="c.name || cIdx"
+                  :name="c.name"
+                  :label="`${c.name} (${c.executables.length})`"
+                  :show-header="false"
+              >
+                <div class="container-content custom-content-bg p-20">
+                  <div class="row mb-20">
+                    <div class="col span-6">
+                      <LabeledInput
+                          :value="c.name"
+                          :label="t('runtimeEnforcer.policyProposal.containerName')"
+                          :mode="mode"
+                          :disabled="true"
+                          :required="true"
+                      />
+                    </div>
+
+                    <div class="col span-6">
+                      <LabeledInput
+                          :value="c.image"
+                          :label="t('runtimeEnforcer.policyProposal.containers.table.image')"
+                          :mode="mode"
+                          :disabled="true"
+                          :required="true"
+                      />
+                    </div>
+                  </div>
+
+                  <div class="executables-header mb-10 d-flex align-center">
+                    <label class="text-bold m-0">
+                      {{ t('runtimeEnforcer.policyProposal.allowedExecutables') }}
+                    </label>
+                    <i class="icon icon-info ml-5 text-muted" />
+                  </div>
+
+                  <!-- Executables Rows -->
+                  <div
+                      v-for="(exec, eIdx) in c.executables"
+                      :key="eIdx"
+                      class="executable-row row mb-10"
+                  >
+                    <div class="col span-6">
+                      <LabeledInput
+                          :value="exec.path"
+                          :placeholder="t('runtimeEnforcer.policyProposal.executablePlaceholder')"
+                          :mode="mode"
+                          @update:value="updateExecutablePath(c.name, eIdx, $event)"
+                      />
+                    </div>
+
+                    <div class="col span-6 align-vertical-center">
+                      <a
+                          class="text-link cursor-pointer"
+                          @click="removeExecutable(c.name, eIdx)"
+                      >
+                        {{ t('generic.remove') }}
+                      </a>
+                    </div>
+                  </div>
+
+                  <div class="row mt-10">
+                    <div class="col span-6">
+                      <a
+                          class="text-primary cursor-pointer text-bold"
+                          @click="addExecutable(c.name)"
+                      >
+                        {{ t('runtimeEnforcer.policyProposal.addExecutable') }}
+                      </a>
+                    </div>
+                  </div>
+                </div>
+              </Tab>
+            </Tabbed>
+          </div>
+        </div>
+      </div>
+    </div>
+  </CruResource>
+</template>
+
+<script>
+import CruResource from '@shell/components/CruResource';
+import { LabeledInput } from '@components/Form/LabeledInput';
+import NameNsDescription from '@shell/components/form/NameNsDescription';
+import Tabbed from '@shell/components/Tabbed';
+import Tab from '@shell/components/Tabbed/Tab';
+import CreateEditView from '@shell/mixins/create-edit-view';
+import Banner from '@components/Banner/Banner';
+import RadioGroup from '@components/Form/Radio/RadioGroup';
+import { POLICY_MODE, WORKLOAD_PREFIX_MAP } from '@runtime-enforcer/types';
+import { WORKLOAD_KIND_TO_TYPE_MAPPING } from '@shell/config/types';
+export default {
+  name: 'WorkloadPolicyEdit',
+
+  components: {
+    CruResource,
+    LabeledInput,
+    NameNsDescription,
+    Tabbed,
+    Tab,
+    Banner,
+    RadioGroup,
+  },
+
+  mixins: [CreateEditView],
+
+  props: {
+    value: {
+      type:     Object,
+      required: true
+    },
+    mode: {
+      type:     String,
+      required: true
+    }
+  },
+
+  data() {
+    return {
+      errors:        [],
+      ownerWorkload: null,
+    };
+  },
+
+  async fetch() {
+    const workloadName = this.workloadName;
+    const namespace = this.value.metadata?.namespace;
+
+    if (!namespace || !workloadName) {
+      return;
+    }
+
+    const fallbackTypes = [...new Set(Object.values(WORKLOAD_KIND_TO_TYPE_MAPPING))];
+
+    const typesToTry = [
+      this.value.ownerWorkloadSteveType,
+      this.ownerWorkloadSteveType,
+      ...fallbackTypes
+    ];
+
+    for (const type of typesToTry) {
+      if (!type) continue;
+      try {
+        this.ownerWorkload = await this.$store.dispatch('cluster/find', {
+          type,
+          id: `${ namespace }/${ workloadName }`,
+        });
+        if (this.ownerWorkload) {
+          break;
+        }
+      } catch (err) {
+        // Silently try next fallback type
+      }
+    }
+  },
+
+  computed: {
+    spec() {
+      if (!this.value.spec) {
+        this.value.spec = {};
+      }
+      if (!this.value.spec.mode) {
+        this.value.spec.mode = POLICY_MODE.PROTECT;
+      }
+
+      return this.value.spec;
+    },
+
+    ownerRef() {
+      return this.value.metadata?.ownerReferences?.[0] || {};
+    },
+
+    workloadName() {
+      if (this.ownerRef.name) {
+        return this.ownerRef.name;
+      }
+      if (this.spec.workload) {
+        return this.spec.workload;
+      }
+      // Fallback: extract workload name from active policy name (e.g. "deploy-gitjob" -> "gitjob")
+      const name = this.value.metadata?.name || '';
+      const parts = name.split('-');
+      if (parts.length > 1) {
+        parts.shift(); // remove prefix like "deploy", "ds", "cronjob"
+        return parts.join('-');
+      }
+      return name;
+    },
+
+    workloadType() {
+      if (this.ownerRef.kind) {
+        return this.ownerRef.kind;
+      }
+      if (this.spec.workloadType) {
+        return this.spec.workloadType;
+      }
+
+      const name = this.value.metadata?.name || '';
+      for (const [prefix, kind] of Object.entries(WORKLOAD_PREFIX_MAP)) {
+        if (name.startsWith(prefix)) {
+          return kind;
+        }
+      }
+
+      return Object.keys(WORKLOAD_KIND_TO_TYPE_MAPPING)[0] || '';
+    },
+
+    ownerWorkloadSteveType() {
+      return WORKLOAD_KIND_TO_TYPE_MAPPING[this.workloadType] || 'apps.deployment';
+    },
+
+    modeRadioOptions() {
+      return [
+        {
+          label: this.t('runtimeEnforcer.activePolicies.mode.protect'),
+          value: POLICY_MODE.PROTECT,
+        },
+        {
+          label: this.t('runtimeEnforcer.activePolicies.mode.monitor'),
+          value: POLICY_MODE.MONITOR,
+        },
+      ];
+    },
+
+    containerImages() {
+      const containers = this.ownerWorkload?.spec?.template?.spec?.containers
+          || this.ownerWorkload?.spec?.jobTemplate?.spec?.template?.spec?.containers
+          || [];
+
+      return containers.reduce((acc, container) => {
+        acc[container.name] = container.image;
+        return acc;
+      }, {});
+    },
+
+    containerList() {
+      const rules = this.spec.rulesByContainer || {};
+
+      return Object.keys(rules).map((containerName) => {
+        const containerRules = rules[containerName] || {};
+        const allowed = containerRules.executables?.allowed || [];
+
+        return {
+          name:        containerName,
+          image:       containerRules.image || this.containerImages[containerName] || this.t('generic.none'),
+          executables: allowed.map((path) => ({
+            path
+          }))
+        };
+      });
+    },
+
+    isValid() {
+      return !!this.value?.metadata?.name;
+    }
+  },
+
+  methods: {
+    ensureRulesPath(containerName) {
+      if (!this.value.spec) {
+        this.value.spec = {};
+      }
+      if (!this.value.spec.rulesByContainer) {
+        this.value.spec.rulesByContainer = {};
+      }
+      if (!this.value.spec.rulesByContainer[containerName]) {
+        this.value.spec.rulesByContainer[containerName] = {};
+      }
+      if (!this.value.spec.rulesByContainer[containerName].executables) {
+        this.value.spec.rulesByContainer[containerName].executables = {};
+      }
+      if (!this.value.spec.rulesByContainer[containerName].executables.allowed) {
+        this.value.spec.rulesByContainer[containerName].executables.allowed = [];
+      }
+
+      return this.value.spec.rulesByContainer[containerName].executables.allowed;
+    },
+
+    addExecutable(containerName) {
+      const allowed = this.ensureRulesPath(containerName);
+
+      allowed.push('');
+    },
+
+    updateExecutablePath(containerName, execIndex, val) {
+      const allowed = this.ensureRulesPath(containerName);
+
+      allowed.splice(execIndex, 1, val);
+    },
+
+    removeExecutable(containerName, execIndex) {
+      const allowed = this.ensureRulesPath(containerName);
+
+      allowed.splice(execIndex, 1);
+    },
+
+    validateForm() {
+      const errors = [];
+      const rules = this.spec.rulesByContainer || {};
+
+      Object.keys(rules).forEach((containerName) => {
+        const allowed = rules[containerName]?.executables?.allowed || [];
+
+        for (let i = 0; i < allowed.length; i++) {
+          const path = (allowed[i] || '').trim();
+
+          if (!path) {
+            errors.push(this.t('runtimeEnforcer.policyProposal.errors.emptyPath', { container: containerName, index: i + 1 }));
+          } else if (!path.startsWith('/')) {
+            errors.push(this.t('runtimeEnforcer.policyProposal.errors.invalidPath', { path, container: containerName }));
+          }
+        }
+      });
+
+      return errors;
+    },
+
+    async savePolicy(buttonDone) {
+      this.errors = [];
+      const rules = this.spec.rulesByContainer || {};
+
+      Object.keys(rules).forEach((containerName) => {
+        if (rules[containerName]?.executables?.allowed) {
+          rules[containerName].executables.allowed = rules[containerName].executables.allowed
+              .map((p) => p.trim())
+              .filter(Boolean);
+        }
+      });
+
+      const validationErrors = this.validateForm();
+
+      if (validationErrors.length) {
+        this.errors = validationErrors;
+        buttonDone(false);
+
+        return;
+      }
+
+      try {
+        await this.value.save();
+        buttonDone(true);
+        this.done();
+      } catch (err) {
+        const apiError = err?.message || err?._statusText || err;
+
+        this.errors = [apiError];
+        buttonDone(false);
+      }
+    },
+
+    cancel() {
+      this.done();
+    }
+  }
+};
+</script>
+
+<style lang="scss">
+.masthead .badge-state {
+  display: none !important;
+}
+</style>
+
+<style lang="scss" scoped>
+.active-policy-edit {
+  .custom-content-bg {
+    background-color: var(--nav-bg, #f4f5f8);
+    border: 1px solid var(--border);
+    border-radius: var(--border-radius);
+  }
+
+  .executable-row {
+    display: flex;
+    align-items: center;
+    width: 100%;
+  }
+
+  .align-vertical-center {
+    display: flex;
+    align-items: center;
+    height: 54px;
+  }
+
+  .cursor-pointer {
+    cursor: pointer;
+  }
+}
+</style>

--- a/pkg/runtime-enforcer/edit/security.rancher.io.workloadpolicy.vue
+++ b/pkg/runtime-enforcer/edit/security.rancher.io.workloadpolicy.vue
@@ -20,6 +20,7 @@
           :value="value"
           :mode="mode"
           name-label="runtimeEnforcer.activePolicies.columns.policy"
+          descriptionPlaceholder="runtimeEnforcer.activePolicy.descriptionPlaceholder"
       />
 
       <div class="row mb-20">
@@ -131,7 +132,7 @@
                   <div class="row mt-10">
                     <div class="col span-6">
                       <a
-                          class="text-primary cursor-pointer text-bold"
+                          class="text-link cursor-pointer px-12"
                           @click="addExecutable(c.name)"
                       >
                         {{ t('runtimeEnforcer.policyProposal.addExecutable') }}
@@ -453,6 +454,11 @@ export default {
 
   .cursor-pointer {
     cursor: pointer;
+  }
+
+  .px-12 {
+    padding-left: 12px;
+    padding-right: 12px;
   }
 }
 </style>

--- a/pkg/runtime-enforcer/edit/security.rancher.io.workloadpolicy.vue
+++ b/pkg/runtime-enforcer/edit/security.rancher.io.workloadpolicy.vue
@@ -158,7 +158,7 @@ import Tab from '@shell/components/Tabbed/Tab';
 import CreateEditView from '@shell/mixins/create-edit-view';
 import Banner from '@components/Banner/Banner';
 import RadioGroup from '@components/Form/Radio/RadioGroup';
-import { POLICY_MODE, WORKLOAD_PREFIX_MAP } from '@runtime-enforcer/types';
+import { POLICY_MODE } from '@runtime-enforcer/types';
 import { WORKLOAD_KIND_TO_TYPE_MAPPING } from '@shell/config/types';
 export default {
   name: 'WorkloadPolicyEdit',
@@ -213,20 +213,12 @@ export default {
       return this.value.spec;
     },
 
-    ownerRef() {
-      return this.value.metadata?.ownerReferences?.[0] || {};
-    },
-
     workloadName() {
-      if (this.value.workloadRef?.workloadName) {
-        return this.value.workloadRef.workloadName;
-      }
+      return this.value.workloadRef?.workloadName || '';
     },
 
     workloadType() {
-      if (this.value.workloadRef?.workloadType) {
-        return this.value.workloadRef.workloadType;
-      }
+      return this.value.workloadRef?.workloadType || '';
     },
 
     ownerWorkloadSteveType() {

--- a/pkg/runtime-enforcer/edit/security.rancher.io.workloadpolicy.vue
+++ b/pkg/runtime-enforcer/edit/security.rancher.io.workloadpolicy.vue
@@ -194,29 +194,11 @@ export default {
   },
 
   async fetch() {
-    // 1. Populate Vuex cache so Steven's `workloadRef` getter can find labeled workloads
     const loadPromises = Object.values(WORKLOAD_KIND_TO_TYPE_MAPPING).map((type) =>
         this.$store.dispatch('cluster/findAll', { type })
     );
 
     await Promise.allSettled(loadPromises);
-
-    // 2. If workloadRef fails (e.g., the workload is missing the policy label), fallback to direct API fetch
-    if (!this.value.workloadRef?.workloadName) {
-      const name = this.workloadName;
-      const type = this.ownerWorkloadSteveType;
-
-      if (name && type) {
-        try {
-          this.ownerWorkload = await this.$store.dispatch('cluster/find', {
-            type,
-            id:   `${ this.value.metadata?.namespace }/${ name }`,
-          });
-        } catch (err) {
-          // Silently try next fallback
-        }
-      }
-    }
   },
 
   computed: {
@@ -236,39 +218,15 @@ export default {
     },
 
     workloadName() {
-      // Try workloadRef first
       if (this.value.workloadRef?.workloadName) {
         return this.value.workloadRef.workloadName;
       }
-
-      // Fallbacks
-      if (this.ownerRef.name) return this.ownerRef.name;
-      if (this.spec.workload) return this.spec.workload;
-
-      const name = this.value.metadata?.name || '';
-      const parts = name.split('-');
-      if (parts.length > 1) {
-        parts.shift();
-        return parts.join('-');
-      }
-      return name;
     },
 
     workloadType() {
-      // Try workloadRef first
       if (this.value.workloadRef?.workloadType) {
         return this.value.workloadRef.workloadType;
       }
-
-      // Fallbacks
-      if (this.ownerRef.kind) return this.ownerRef.kind;
-      if (this.spec.workloadType) return this.spec.workloadType;
-
-      const name = this.value.metadata?.name || '';
-      for (const [prefix, kind] of Object.entries(WORKLOAD_PREFIX_MAP)) {
-        if (name.startsWith(prefix)) return kind;
-      }
-      return Object.keys(WORKLOAD_KIND_TO_TYPE_MAPPING)[0] || '';
     },
 
     ownerWorkloadSteveType() {
@@ -289,21 +247,10 @@ export default {
     },
 
     containerImages() {
-      // 1. Attempt to use Steven's imageMap from workloadRef
       const refImages = this.value.workloadRef?.imageMap;
       if (refImages && Object.keys(refImages).length > 0) {
         return refImages;
       }
-
-      // 2. Fallback to reading from the network-fetched ownerWorkload
-      const containers = this.ownerWorkload?.spec?.template?.spec?.containers
-          || this.ownerWorkload?.spec?.jobTemplate?.spec?.template?.spec?.containers
-          || [];
-
-      return containers.reduce((acc, container) => {
-        acc[container.name] = container.image;
-        return acc;
-      }, {});
     },
 
     containerList() {
@@ -315,7 +262,7 @@ export default {
 
         return {
           name:        containerName,
-          image:       containerRules.image || this.containerImages[containerName] || this.t('generic.none'),
+          image:       containerRules.image || this.containerImages?.[containerName] || this.t('generic.none'),
           executables: allowed.map((path) => ({
             path
           }))

--- a/pkg/runtime-enforcer/edit/security.rancher.io.workloadpolicy.vue
+++ b/pkg/runtime-enforcer/edit/security.rancher.io.workloadpolicy.vue
@@ -194,33 +194,27 @@ export default {
   },
 
   async fetch() {
-    const workloadName = this.workloadName;
-    const namespace = this.value.metadata?.namespace;
+    // 1. Populate Vuex cache so Steven's `workloadRef` getter can find labeled workloads
+    const loadPromises = Object.values(WORKLOAD_KIND_TO_TYPE_MAPPING).map((type) =>
+        this.$store.dispatch('cluster/findAll', { type })
+    );
 
-    if (!namespace || !workloadName) {
-      return;
-    }
+    await Promise.allSettled(loadPromises);
 
-    const fallbackTypes = [...new Set(Object.values(WORKLOAD_KIND_TO_TYPE_MAPPING))];
+    // 2. If workloadRef fails (e.g., the workload is missing the policy label), fallback to direct API fetch
+    if (!this.value.workloadRef?.workloadName) {
+      const name = this.workloadName;
+      const type = this.ownerWorkloadSteveType;
 
-    const typesToTry = [
-      this.value.ownerWorkloadSteveType,
-      this.ownerWorkloadSteveType,
-      ...fallbackTypes
-    ];
-
-    for (const type of typesToTry) {
-      if (!type) continue;
-      try {
-        this.ownerWorkload = await this.$store.dispatch('cluster/find', {
-          type,
-          id: `${ namespace }/${ workloadName }`,
-        });
-        if (this.ownerWorkload) {
-          break;
+      if (name && type) {
+        try {
+          this.ownerWorkload = await this.$store.dispatch('cluster/find', {
+            type,
+            id:   `${ this.value.metadata?.namespace }/${ name }`,
+          });
+        } catch (err) {
+          // Silently try next fallback
         }
-      } catch (err) {
-        // Silently try next fallback type
       }
     }
   },
@@ -242,37 +236,38 @@ export default {
     },
 
     workloadName() {
-      if (this.ownerRef.name) {
-        return this.ownerRef.name;
+      // Try workloadRef first
+      if (this.value.workloadRef?.workloadName) {
+        return this.value.workloadRef.workloadName;
       }
-      if (this.spec.workload) {
-        return this.spec.workload;
-      }
-      // Fallback: extract workload name from active policy name (e.g. "deploy-gitjob" -> "gitjob")
+
+      // Fallbacks
+      if (this.ownerRef.name) return this.ownerRef.name;
+      if (this.spec.workload) return this.spec.workload;
+
       const name = this.value.metadata?.name || '';
       const parts = name.split('-');
       if (parts.length > 1) {
-        parts.shift(); // remove prefix like "deploy", "ds", "cronjob"
+        parts.shift();
         return parts.join('-');
       }
       return name;
     },
 
     workloadType() {
-      if (this.ownerRef.kind) {
-        return this.ownerRef.kind;
+      // Try workloadRef first
+      if (this.value.workloadRef?.workloadType) {
+        return this.value.workloadRef.workloadType;
       }
-      if (this.spec.workloadType) {
-        return this.spec.workloadType;
-      }
+
+      // Fallbacks
+      if (this.ownerRef.kind) return this.ownerRef.kind;
+      if (this.spec.workloadType) return this.spec.workloadType;
 
       const name = this.value.metadata?.name || '';
       for (const [prefix, kind] of Object.entries(WORKLOAD_PREFIX_MAP)) {
-        if (name.startsWith(prefix)) {
-          return kind;
-        }
+        if (name.startsWith(prefix)) return kind;
       }
-
       return Object.keys(WORKLOAD_KIND_TO_TYPE_MAPPING)[0] || '';
     },
 
@@ -294,6 +289,13 @@ export default {
     },
 
     containerImages() {
+      // 1. Attempt to use Steven's imageMap from workloadRef
+      const refImages = this.value.workloadRef?.imageMap;
+      if (refImages && Object.keys(refImages).length > 0) {
+        return refImages;
+      }
+
+      // 2. Fallback to reading from the network-fetched ownerWorkload
       const containers = this.ownerWorkload?.spec?.template?.spec?.containers
           || this.ownerWorkload?.spec?.jobTemplate?.spec?.template?.spec?.containers
           || [];

--- a/pkg/runtime-enforcer/edit/security.rancher.io.workloadpolicyproposal.vue
+++ b/pkg/runtime-enforcer/edit/security.rancher.io.workloadpolicyproposal.vue
@@ -21,6 +21,7 @@
           :value="value"
           :mode="mode"
           name-label="runtimeEnforcer.policyProposal.policyName"
+          descriptionPlaceholder="runtimeEnforcer.policyProposal.descriptionPlaceholder"
       />
 
       <div class="row mb-20">
@@ -123,7 +124,7 @@
                   <div class="row mt-10">
                     <div class="col span-6">
                       <a
-                          class="text-primary cursor-pointer px-12"
+                          class="text-link cursor-pointer px-12"
                           @click="addExecutable(c.name)"
                       >
                         {{ t('runtimeEnforcer.policyProposal.addExecutable') }}

--- a/pkg/runtime-enforcer/models/__tests__/security.rancher.io.workloadpolicyproposal.spec.ts
+++ b/pkg/runtime-enforcer/models/__tests__/security.rancher.io.workloadpolicyproposal.spec.ts
@@ -296,10 +296,9 @@ describe('WorkloadPolicyProposal model', () => {
 
   describe('editPolicy / exportPolicy / promote', () => {
     it('editPolicy() does not throw', () => {
-      proposal.detailLocation = { query: {} };
-      proposal.currentRouter = () => ({ push: jest.fn() });
-
+      proposal.goToEdit = jest.fn();
       expect(() => proposal.editPolicy()).not.toThrow();
+      expect(proposal.goToEdit).toHaveBeenCalled();
     });
 
     it('exportPolicy() dispatches promptModal with itself as the sole resource by default', () => {

--- a/pkg/runtime-enforcer/models/security.rancher.io.workloadpolicy.js
+++ b/pkg/runtime-enforcer/models/security.rancher.io.workloadpolicy.js
@@ -95,7 +95,7 @@ export default class WorkloadPolicyProposal extends SteveModel {
             || workload.spec?.jobTemplate?.spec?.template?.spec?.containers
             || [];
 
-          const image = containers.reduce((acc, container) => {
+          const imageMap = containers.reduce((acc, container) => {
             acc[container.name] = container.image;
 
             return acc;
@@ -105,6 +105,7 @@ export default class WorkloadPolicyProposal extends SteveModel {
             workloadName:     workload.metadata?.name || '',
             workloadType:     workload.kind || '',
             workloadLocation: `/c/${ cluster }/${ PRODUCT_NAME }/${ WORKLOAD_KIND_TO_TYPE_MAPPING[workload.kind] || '' }/${ workload.metadata?.namespace || '' }/${ workload.metadata?.name || '' }`,
+            imageMap,
           };
         }
 
@@ -112,13 +113,14 @@ export default class WorkloadPolicyProposal extends SteveModel {
           workloadName:     '',
           workloadType:     '',
           workloadLocation: '',
+          imageMap:         {},
         };
       } catch {
         return {
           workloadName:     '',
           workloadType:     '',
           workloadLocation: '',
-          imageMap:     null,
+          imageMap:         {}
         };
       }
     })();

--- a/pkg/runtime-enforcer/models/security.rancher.io.workloadpolicy.js
+++ b/pkg/runtime-enforcer/models/security.rancher.io.workloadpolicy.js
@@ -182,4 +182,9 @@ export default class WorkloadPolicyProposal extends SteveModel {
       modalWidth:     '640',
     });
   }
+
+  editPolicy() {
+    this.goToEdit();
+  }
+
 }

--- a/pkg/runtime-enforcer/models/security.rancher.io.workloadpolicyproposal.js
+++ b/pkg/runtime-enforcer/models/security.rancher.io.workloadpolicyproposal.js
@@ -170,14 +170,7 @@ export default class WorkloadPolicyProposal extends SteveModel {
   }
 
   editPolicy() {
-    const location = this.detailLocation;
-
-    location.query = {
-      ...location.query,
-      mode: 'edit'
-    };
-
-    this.currentRouter().push(location);
+    this.goToEdit();
   }
 
   exportPolicy(resources = this) {

--- a/pkg/runtime-enforcer/types/runtime-enforcer.ts
+++ b/pkg/runtime-enforcer/types/runtime-enforcer.ts
@@ -113,13 +113,6 @@ export const RUNTIME_ENFORCER = {
   SCHEMA:     RESOURCE.POLICY_PROPOSALS,
 };
 
-export const WORKLOAD_PREFIX_MAP: Record<string, string> = {
-  'ds-': 'DaemonSet',
-  'ss-': 'StatefulSet',
-  'cronjob-': 'CronJob',
-  'deployment-': 'Deployment',
-};
-
 export const CERT_MANAGER_CSI_DRIVER = {
   CONTROLLER: 'cert-manager-csi-driver',
   CHART_NAME: 'cert-manager-csi-driver',

--- a/pkg/runtime-enforcer/types/runtime-enforcer.ts
+++ b/pkg/runtime-enforcer/types/runtime-enforcer.ts
@@ -113,6 +113,13 @@ export const RUNTIME_ENFORCER = {
   SCHEMA:     RESOURCE.POLICY_PROPOSALS,
 };
 
+export const WORKLOAD_PREFIX_MAP: Record<string, string> = {
+  'ds-': 'DaemonSet',
+  'ss-': 'StatefulSet',
+  'cronjob-': 'CronJob',
+  'deployment-': 'Deployment',
+};
+
 export const CERT_MANAGER_CSI_DRIVER = {
   CONTROLLER: 'cert-manager-csi-driver',
   CHART_NAME: 'cert-manager-csi-driver',


### PR DESCRIPTION
## Description

Fix #674 

implements the UI for the Runtime Enforcer Active Policy edit page

## Test

1. Log in and navigate to the **Runtime Enforcer** section.
2. Select an Active Policy and open the **Edit Policy** page.
3. Verify that the policy edit form loads correctly.
4. Add and remove executables, then save the form to verify that the changes are successfully persisted.

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

<img width="1895" height="945" alt="Screenshot 2026-07-31 at 8 34 32 AM" src="https://github.com/user-attachments/assets/aab1ea3d-f7cf-4668-86b6-c27ce7bf3c8e" />
