### PR TITLE
#685 Runtime Enforcer: Retrieve workload information for active policy data.

### DIFF
--- a/pkg/runtime-enforcer/config/policy-proposals-table.ts
+++ b/pkg/runtime-enforcer/config/policy-proposals-table.ts
@@ -161,16 +161,16 @@ export function getActivePoliciesHeaders() {
     {
       name:     'workload',
       labelKey: 'runtimeEnforcer.activePolicies.columns.workload',
-      value:    'metadata.ownerReferences.0.name',
-      sort:     'metadata.ownerReferences.0.name',
+      value:    'workloadRef.workloadName',
+      sort:     'workloadRef.workloadName',
       formatter: 'WorkloadRouteLink',
       width:    FIGMA_COLUMN_WIDTH.workload,
     },
     {
       name:     'workloadType',
       labelKey: 'runtimeEnforcer.activePolicies.columns.workloadType',
-      value:    'metadata.ownerReferences.0.kind',
-      sort:     'metadata.ownerReferences.0.kind',
+      value:    'workloadRef.workloadType',
+      sort:     'workloadRef.workloadType',
       width:    FIGMA_COLUMN_WIDTH.workloadType,
     },
     {

--- a/pkg/runtime-enforcer/detail/security.rancher.io.workloadpolicy.vue
+++ b/pkg/runtime-enforcer/detail/security.rancher.io.workloadpolicy.vue
@@ -14,6 +14,7 @@ import { PRODUCT_NAME, RESOURCE } from '@runtime-enforcer/types';
 import ActionMenu from '@shell/components/ActionMenuShell.vue';
 import StatusBadge from '@runtime-enforcer/components/common/StatusBadge.vue';
 import ExpandableDescription from '@common/components/ExpandableDescription.vue';
+import { WORKLOAD_KIND_TO_TYPE_MAPPING } from '@shell/config/types';
 
 
 const props = defineProps<{
@@ -28,10 +29,10 @@ const i18n = useI18n(store);
 
 const canUpdate = computed(() => policy.canUpdate);
 
-const ownerWorkload = ref<any>(null);
-
 onMounted(async() => {
-  //ToDo: Prepare to get wroklaod info from backend data
+  if (!policy.workloadRef?.workloadName && !policy.workloadRef?.workloadType) {
+    await getWorkloadData();
+  }
 });
 
 const namespaceRoute = computed(() => ({
@@ -43,6 +44,14 @@ const namespaceRoute = computed(() => ({
     id:       policy.metadata?.namespace,
   },
 }));
+
+const getWorkloadData = async() => {
+  return Promise.all(
+    Object.values(WORKLOAD_KIND_TO_TYPE_MAPPING).map((workloadType) =>
+      store.dispatch(`cluster/findAll`, { type: workloadType })
+    )
+  );
+};
 
 const modetext = computed(() => {
   return i18n.t(`runtimeEnforcer.activePolicies.mode.${policy.spec.mode.toLowerCase()}`);
@@ -66,15 +75,15 @@ const metaProperties = computed<MetadataProperty[]>(() => [
     route: namespaceRoute.value,
   },
   {
-    type:  ownerWorkload.value ? 'route' : 'text',
+    type:  'route',
     label: i18n.t('runtimeEnforcer.activePolicy.masthead.workload'),
-    value: '',//policy.workload,
-    route: ownerWorkload.value?.detailLocation,
+    value: policy.workloadRef?.workloadName ?? '',
+    route: policy.workloadRef?.workloadLocation ?? null,
   },
   {
     type:  'text',
     label: i18n.t('runtimeEnforcer.activePolicy.masthead.workloadType'),
-    value: '',//policy.workloadType,
+    value: policy.workloadRef?.workloadType ?? '',
   },
   {
     type:  'icon',

--- a/pkg/runtime-enforcer/dialog/DeletePolicyProposalsDialog.vue
+++ b/pkg/runtime-enforcer/dialog/DeletePolicyProposalsDialog.vue
@@ -2,9 +2,10 @@
 import { Card } from '@components/Card';
 import { Banner } from '@components/Banner';
 import RcButton from '@components/RcButton/RcButton.vue';
-import { PRODUCT_NAME } from '@runtime-enforcer/types/runtime-enforcer.ts';
+import { PRODUCT_NAME } from '@runtime-enforcer/types';
 import { exceptionToErrorsArray } from '@shell/utils/error';
 import { TIMESTAMP } from '@shell/config/labels-annotations';
+import { WORKLOAD_KIND_TO_TYPE_MAPPING } from '@shell/config/types';
 
 export default {
   emits: ['close'],
@@ -79,7 +80,7 @@ export default {
         console.log('Fetch the workload based on type:', resource);
 
         const workload = await this.$store.dispatch('cluster/find', {
-          type: resource.ownerWorkloadSteveType,
+          type: WORKLOAD_KIND_TO_TYPE_MAPPING[resource.metadata?.ownerReferences?.[0]?.kind],
           id:   `${ resource.metadata.namespace }/${ resource.metadata.ownerReferences?.[0]?.name }`,
         });
 
@@ -90,7 +91,13 @@ export default {
           return;
         }
 
-        const metadata = workload.spec.template.metadata ??= {};
+        const podTemplate = workload.spec?.jobTemplate?.spec?.template ?? workload.spec?.template;
+
+        if (!podTemplate) {
+          return;
+        }
+
+        const metadata = podTemplate.metadata ??= {};
         const annotations = metadata.annotations ??= {};
 
         annotations[TIMESTAMP] = now;

--- a/pkg/runtime-enforcer/dialog/ImportDialog.vue
+++ b/pkg/runtime-enforcer/dialog/ImportDialog.vue
@@ -1,0 +1,322 @@
+<script>
+import { mapGetters } from 'vuex';
+import { Card } from '@components/Card';
+import { Banner } from '@components/Banner';
+import YamlEditor from '@shell/components/YamlEditor';
+import FileSelector from '@shell/components/form/FileSelector';
+import AsyncButton from '@shell/components/AsyncButton';
+import LabeledSelect from '@shell/components/form/LabeledSelect';
+import SortableTable from '@shell/components/SortableTable';
+import { sortBy } from '@shell/utils/sort';
+import { exceptionToErrorsArray } from '@shell/utils/error';
+import { NAMESPACE } from '@shell/config/types';
+import { NAME as NAME_COL, TYPE, NAMESPACE as NAMESPACE_COL, AGE } from '@shell/config/table-headers';
+import RcButton from '@components/RcButton/RcButton.vue';
+
+export default {
+  emits: ['close', 'onReadyYamlEditor'],
+
+  components: {
+    AsyncButton,
+    Banner,
+    Card,
+    YamlEditor,
+    FileSelector,
+    LabeledSelect,
+    SortableTable,
+    RcButton
+  },
+
+  props: {
+    defaultNamespace: {
+      type:    String,
+      default: undefined
+    },
+  },
+
+  async fetch() {
+    this.allNamespaces = (await this.$store.dispatch('cluster/findAll', { type: NAMESPACE, opt: { url: 'namespaces' } })) || [];
+
+    if (this.selectedNamespace === undefined) {
+      const defaultNamespace = 'default';
+      const hasAccessToDefaultNamespace = this.allNamespaces.some((ns) => ns.name === defaultNamespace);
+
+      this.selectedNamespace = hasAccessToDefaultNamespace ? defaultNamespace : this.allNamespaces[0]?.name;
+    }
+  },
+
+  mounted() {
+    //Override the parent layer (Dialog) from Card component for the border radius
+    const parent = document.querySelector('.import-dialog-card')?.closest('.modal-container');
+
+    parent?.classList.add('import-dialog-container');
+
+    if (parent) {
+      parent.style.borderRadius = '8px';
+    }
+  },
+
+  data() {
+    return {
+      currentYaml:       '',
+      allNamespaces:     [],
+      errors:            null,
+      rows:              null,
+      done:              false,
+      selectedNamespace: this.defaultNamespace,
+    };
+  },
+
+  computed: {
+    ...mapGetters(['currentCluster']),
+
+    namespaceOptions() {
+      const out = this.allNamespaces.map((obj) => {
+        return {
+          label: obj.name,
+          value: obj.name,
+        };
+      });
+
+      return sortBy(out, 'label');
+    },
+
+    headers() {
+      return [
+        TYPE,
+        NAME_COL,
+        NAMESPACE_COL,
+        AGE
+      ];
+    },
+  },
+
+  methods: {
+    close() {
+      this.$emit('close');
+    },
+
+    onFileSelected(value) {
+      const component = this.$refs.yamleditor;
+
+      if (component) {
+        this.errors = null;
+        component.updateValue(value);
+      }
+    },
+
+    async importYaml(btnCb) {
+      try {
+        this.errors = [];
+
+        const res = await this.currentCluster.doAction('apply', {
+          yaml:             this.currentYaml,
+          defaultNamespace: this.selectedNamespace,
+        });
+
+        btnCb(true);
+
+        this.rows = res;
+        this.done = true;
+      } catch (err) {
+        this.errors = exceptionToErrorsArray(err);
+        this.done = false;
+        btnCb(false);
+      }
+    },
+
+    rowClick(e) {
+      if ( e.target.tagName === 'A' ) {
+        this.close();
+      }
+    },
+
+    onReadyYamlEditor(arg) {
+      this.$emit('onReadyYamlEditor', arg);
+    }
+  },
+};
+</script>
+
+<template>
+  <Card
+    :show-highlight-border="false"
+    data-testid="import-yaml"
+    class="import-dialog-card"
+  >
+    <template #title>
+      <div style="display: block; width: 100%;">
+        <template v-if="done">
+          <h4 data-testid="import-yaml-success">
+            {{ t('import.success', {count: rows.length}) }}
+          </h4>
+        </template>
+        <template v-else>
+          <h4 v-t="'import.title'" />
+          <!-- Added import instruction banner -->
+          <Banner
+            class="import-instruction-banner"
+            color="info"
+          >
+            <span class="banner-text">
+              {{ t('runtimeEnforcer.activePolicies.import.instruction') }}
+            </span>
+          </Banner>
+          <div class="row">
+            <div class="col span-6">
+              <FileSelector
+                role="button"
+                :aria-label="t('generic.readFromFileArea', { area: t('import.title') })"
+                class="btn role-secondary pull-left medium"
+                :label="t('generic.readFromFile')"
+                @selected="onFileSelected"
+              />
+            </div>
+            <!-- Changed the layout of the namespace select -->
+            <div class="col span-6 namespace-col">
+              <label>{{ t('runtimeEnforcer.activePolicy.masthead.namespace') }}</label>
+              <LabeledSelect
+                class="namespace-select"
+                v-model:value="selectedNamespace"
+                :options="namespaceOptions"
+                mode="edit"
+              />
+            </div>
+          </div>
+        </template>
+      </div>
+    </template>
+    <template #body>
+      <template v-if="done">
+        <div class="results">
+          <SortableTable
+            :rows="rows"
+            :headers="headers"
+            mode="view"
+            key-field="_key"
+            :search="false"
+            :paging="true"
+            :row-actions="false"
+            :table-actions="false"
+            :sub-rows-description="false"
+            @rowClick="rowClick"
+          />
+        </div>
+      </template>
+      <YamlEditor
+        v-else
+        ref="yamleditor"
+        v-model:value="currentYaml"
+        class="yaml-editor"
+        @onReady="onReadyYamlEditor"
+      />
+      <Banner
+        v-for="(err, i) in errors"
+        :key="i"
+        color="error"
+        :label="err"
+      />
+    </template>
+    <template #actions>
+      <div
+        v-if="done"
+        class="text-center"
+        style="width: 100%"
+      >
+        <button
+          :aria-label="t('generic.close')"
+          role="button"
+          type="button"
+          class="btn role-primary"
+          data-testid="import-yaml-close"
+          @click="close"
+        >
+          {{ t('generic.close') }}
+        </button>
+      </div>
+      <!-- Changed the style of the buttons -->
+      <div
+        v-else
+        class="text-right"
+        style="width: 100%"
+      >
+        <RcButton
+          variant="link"
+          size="large"
+          @click="close"
+        >
+          {{ t('generic.cancel') }}
+        </RcButton>
+        <AsyncButton
+          v-if="!done"
+          icon="icon-upload"
+          class="import-btn"
+          mode="import"
+          :disabled="!currentYaml.length"
+          data-testid="import-yaml-import-action"
+          :aria-label="t('import.title')"
+          @click="importYaml"
+        />
+      </div>
+    </template>
+  </Card>
+</template>
+
+<style lang='scss' scoped>
+  $min: 50vh;
+  $max: 50vh;
+
+  .yaml-editor {
+    flex: 1;
+    min-height: $min;
+    max-height: $max;
+
+    :deep() .code-mirror {
+      .CodeMirror {
+        position: initial;
+      }
+
+      .CodeMirror,
+      .CodeMirror-scroll,
+      .CodeMirror-gutters {
+        min-height: $min;
+        max-height: $max;
+      }
+    }
+  }
+
+  //Override the class style from Card component for the box shadow
+  .import-dialog-card {
+    box-shadow: none !important;
+  }
+
+  .import-instruction-banner {
+    margin: 16px 0 24px 0;
+  }
+
+  .medium {
+    height: 32px !important;
+    min-height: 32px !important;
+  }
+
+  .namespace-select {
+    max-width: 300px;
+  }
+
+  .namespace-col {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 8px;
+
+    label {
+      margin: 0;
+      white-space: nowrap;
+    }
+  }
+
+  .import-btn {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+</style>

--- a/pkg/runtime-enforcer/dialog/__tests__/DeletePolicyProposalsDialog.spec.ts
+++ b/pkg/runtime-enforcer/dialog/__tests__/DeletePolicyProposalsDialog.spec.ts
@@ -14,7 +14,7 @@ const createResource = (name = 'proposal-a', workloadName?: string) => ({
   nameDisplay: name,
   metadata: {
     namespace:       'runtime-enforcer',
-    ownerReferences: workloadName ? [{ name: workloadName }] : [],
+    ownerReferences: workloadName ? [{ kind: 'Deployment', name: workloadName }] : [],
   },
   ownerWorkloadSteveType: 'apps.deployment',
   remove:                 jest.fn().mockResolvedValue(undefined),

--- a/pkg/runtime-enforcer/dialog/__tests__/ImportDialog.spec.ts
+++ b/pkg/runtime-enforcer/dialog/__tests__/ImportDialog.spec.ts
@@ -1,0 +1,275 @@
+import { shallowMount } from '@vue/test-utils';
+import ImportDialog from '../ImportDialog.vue';
+import { exceptionToErrorsArray } from '@shell/utils/error';
+import { NAMESPACE } from '@shell/config/types';
+import { NAME as NAME_COL, TYPE, NAMESPACE as NAMESPACE_COL, AGE } from '@shell/config/table-headers';
+
+jest.mock('@shell/utils/error', () => ({
+  exceptionToErrorsArray: jest.fn((err) => [err]),
+}));
+
+const t = jest.fn((key, args, raw) => (raw ? `${ key }:${ JSON.stringify(args) }` : key));
+
+const createNamespace = (name: string) => ({ name });
+
+const createWrapper = ({
+  defaultNamespace,
+  doAction = jest.fn(),
+  dispatch = jest.fn(),
+  attachTo,
+}: {
+  defaultNamespace?: string,
+  doAction?: jest.Mock,
+  dispatch?: jest.Mock,
+  attachTo?: HTMLElement,
+} = {}) => {
+  return shallowMount(ImportDialog as any, {
+    props: { defaultNamespace },
+    attachTo,
+    global: {
+      mocks: {
+        t,
+        $store: {
+          dispatch,
+          getters: {
+            currentCluster: { doAction },
+          },
+        },
+      },
+      directives: {
+        t: () => undefined,
+        'clean-html': () => undefined,
+      },
+      stubs: {
+        FileSelector: true,
+        LabeledSelect: true,
+        SortableTable: true,
+        YamlEditor: true,
+        Banner: true,
+        Card: true,
+        AsyncButton: true,
+        RcButton: true,
+      },
+    },
+  });
+};
+
+describe('ImportDialog', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('computed', () => {
+    it('namespaceOptions maps and sorts namespaces by label', () => {
+      const wrapper = createWrapper();
+
+      (wrapper.vm as any).allNamespaces = [
+        createNamespace('zeta'),
+        createNamespace('alpha'),
+        createNamespace('middle'),
+      ];
+
+      expect((wrapper.vm as any).namespaceOptions).toEqual([
+        { label: 'alpha', value: 'alpha' },
+        { label: 'middle', value: 'middle' },
+        { label: 'zeta', value: 'zeta' },
+      ]);
+    });
+
+    it('headers returns expected static table headers', () => {
+      const wrapper = createWrapper();
+
+      expect((wrapper.vm as any).headers).toEqual([TYPE, NAME_COL, NAMESPACE_COL, AGE]);
+    });
+  });
+
+  describe('fetch', () => {
+    it('loads namespaces and sets selected namespace to default when available', async() => {
+      const dispatch = jest.fn().mockResolvedValue([
+        createNamespace('kube-system'),
+        createNamespace('default'),
+      ]);
+      const wrapper = createWrapper({ dispatch });
+
+      (wrapper.vm as any).selectedNamespace = undefined;
+      await (wrapper.vm as any).$options.fetch.call(wrapper.vm);
+
+      expect(dispatch).toHaveBeenCalledWith('cluster/findAll', {
+        type: NAMESPACE,
+        opt:  { url: 'namespaces' },
+      });
+      expect((wrapper.vm as any).allNamespaces).toEqual([
+        createNamespace('kube-system'),
+        createNamespace('default'),
+      ]);
+      expect((wrapper.vm as any).selectedNamespace).toBe('default');
+    });
+
+    it('uses first namespace when default is not accessible', async() => {
+      const dispatch = jest.fn().mockResolvedValue([
+        createNamespace('team-a'),
+        createNamespace('team-b'),
+      ]);
+      const wrapper = createWrapper({ dispatch });
+
+      (wrapper.vm as any).selectedNamespace = undefined;
+      await (wrapper.vm as any).$options.fetch.call(wrapper.vm);
+
+      expect((wrapper.vm as any).selectedNamespace).toBe('team-a');
+    });
+
+    it('keeps selected namespace when already set', async() => {
+      const dispatch = jest.fn().mockResolvedValue([
+        createNamespace('default'),
+        createNamespace('team-a'),
+      ]);
+      const wrapper = createWrapper({ dispatch, defaultNamespace: 'preset-ns' });
+
+      await (wrapper.vm as any).$options.fetch.call(wrapper.vm);
+
+      expect((wrapper.vm as any).selectedNamespace).toBe('preset-ns');
+    });
+
+    it('handles null namespace response as empty list', async() => {
+      const dispatch = jest.fn().mockResolvedValue(null);
+      const wrapper = createWrapper({ dispatch });
+
+      (wrapper.vm as any).selectedNamespace = undefined;
+      await (wrapper.vm as any).$options.fetch.call(wrapper.vm);
+
+      expect((wrapper.vm as any).allNamespaces).toEqual([]);
+      expect((wrapper.vm as any).selectedNamespace).toBeUndefined();
+    });
+  });
+
+  describe('mounted', () => {
+    it('adds import container class and border radius to modal container parent', () => {
+      const host = document.createElement('div');
+
+      host.className = 'modal-container';
+      document.body.appendChild(host);
+
+      const wrapper = createWrapper({ attachTo: host });
+
+      expect(host.classList.contains('import-dialog-container')).toBe(true);
+      expect(host.style.borderRadius).toBe('8px');
+
+      wrapper.unmount();
+      host.remove();
+    });
+
+    it('does nothing when no modal container parent exists', () => {
+      const wrapper = createWrapper();
+
+      expect((wrapper.vm as any)).toBeTruthy();
+    });
+  });
+
+  describe('methods', () => {
+    it('close emits close event', () => {
+      const wrapper = createWrapper();
+
+      (wrapper.vm as any).close();
+
+      expect(wrapper.emitted('close')).toHaveLength(1);
+    });
+
+    it('onFileSelected clears errors and updates editor value when editor ref exists', () => {
+      const wrapper = createWrapper();
+      const updateValue = jest.fn();
+      const ctx: any = {
+        errors: ['old'],
+        $refs:  {
+          yamleditor: { updateValue },
+        },
+      };
+
+      (wrapper.vm as any).$options.methods.onFileSelected.call(ctx, 'kind: ConfigMap');
+
+      expect(ctx.errors).toBeNull();
+      expect(updateValue).toHaveBeenCalledWith('kind: ConfigMap');
+    });
+
+    it('onFileSelected is a no-op when editor ref is missing', () => {
+      const wrapper = createWrapper();
+      const ctx: any = {
+        errors: ['old'],
+        $refs:  {},
+      };
+
+      (wrapper.vm as any).$options.methods.onFileSelected.call(ctx, 'kind: Secret');
+
+      expect(ctx.errors).toEqual(['old']);
+    });
+
+    it('importYaml success applies yaml and sets rows/done', async() => {
+      const res = [{ _key: '1' }];
+      const doAction = jest.fn().mockResolvedValue(res);
+      const btnCb = jest.fn();
+      const wrapper = createWrapper({ doAction });
+
+      (wrapper.vm as any).currentYaml = 'apiVersion: v1';
+      (wrapper.vm as any).selectedNamespace = 'team-a';
+      (wrapper.vm as any).errors = ['old'];
+
+      await (wrapper.vm as any).importYaml(btnCb);
+
+      expect((wrapper.vm as any).errors).toEqual([]);
+      expect(doAction).toHaveBeenCalledWith('apply', {
+        yaml:             'apiVersion: v1',
+        defaultNamespace: 'team-a',
+      });
+      expect(btnCb).toHaveBeenCalledWith(true);
+      expect((wrapper.vm as any).rows).toEqual(res);
+      expect((wrapper.vm as any).done).toBe(true);
+    });
+
+    it('importYaml failure formats errors and marks done false', async() => {
+      const err = new Error('apply failed');
+      const doAction = jest.fn().mockRejectedValue(err);
+      const btnCb = jest.fn();
+      const wrapper = createWrapper({ doAction });
+      const mockedExceptionToErrorsArray = exceptionToErrorsArray as jest.Mock;
+
+      mockedExceptionToErrorsArray.mockReturnValueOnce(['formatted-error']);
+
+      (wrapper.vm as any).currentYaml = 'bad yaml';
+      (wrapper.vm as any).selectedNamespace = 'team-a';
+      (wrapper.vm as any).done = true;
+
+      await (wrapper.vm as any).importYaml(btnCb);
+
+      expect(mockedExceptionToErrorsArray).toHaveBeenCalledWith(err);
+      expect((wrapper.vm as any).errors).toEqual(['formatted-error']);
+      expect((wrapper.vm as any).done).toBe(false);
+      expect(btnCb).toHaveBeenCalledWith(false);
+    });
+
+    it('rowClick closes dialog when clicking a link', () => {
+      const wrapper = createWrapper();
+      const closeSpy = jest.spyOn(wrapper.vm as any, 'close').mockImplementation(() => undefined);
+
+      (wrapper.vm as any).rowClick({ target: { tagName: 'A' } });
+
+      expect(closeSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('rowClick does not close for non-link targets', () => {
+      const wrapper = createWrapper();
+      const closeSpy = jest.spyOn(wrapper.vm as any, 'close').mockImplementation(() => undefined);
+
+      (wrapper.vm as any).rowClick({ target: { tagName: 'SPAN' } });
+
+      expect(closeSpy).not.toHaveBeenCalled();
+    });
+
+    it('onReadyYamlEditor emits payload', () => {
+      const wrapper = createWrapper();
+      const arg = { editor: 'ready' };
+
+      (wrapper.vm as any).onReadyYamlEditor(arg);
+
+      expect(wrapper.emitted('onReadyYamlEditor')).toEqual([[arg]]);
+    });
+  });
+});

--- a/pkg/runtime-enforcer/formatters/WorkloadRouteLink.vue
+++ b/pkg/runtime-enforcer/formatters/WorkloadRouteLink.vue
@@ -13,7 +13,8 @@
 </template>
 
 <script>
-import { RESOURCE, PRODUCT_NAME } from '@runtime-enforcer/types';
+import { PRODUCT_NAME } from '@runtime-enforcer/types';
+import { WORKLOAD_KIND_TO_TYPE_MAPPING } from '@shell/config/types';
 export default {
   name:  'WorkloadRouteLink',
   props: {
@@ -33,7 +34,7 @@ export default {
     workloadDetailLink() {
       const cluster = this.$route.params.cluster;
 
-      return `/c/${ cluster }/${ PRODUCT_NAME }/${ this.row?.ownerWorkloadSteveType || '' }/${ this.row?.metadata?.namespace || '' }/${ this.workloadValue }`;
+      return `/c/${ cluster }/${ PRODUCT_NAME }/${ this.row?.ownerWorkloadSteveType || WORKLOAD_KIND_TO_TYPE_MAPPING[this.row?.workloadRef.workloadType || ''] || '' }/${ this.row?.metadata?.namespace || '' }/${ this.workloadValue }`;
     }
   }
 };

--- a/pkg/runtime-enforcer/list/security.rancher.io.workloadpolicy.vue
+++ b/pkg/runtime-enforcer/list/security.rancher.io.workloadpolicy.vue
@@ -28,7 +28,7 @@ function getAnyFilterOption() {
     label: t('runtimeEnforcer.activePolicies.filters.any')
   };
 }
-a
+
 const filters = ref({
   policySearch:   '',
   workloadSearch: '',
@@ -219,7 +219,7 @@ async function fetchSecondaryResources({ canPaginate }: { canPaginate: boolean }
     return;
   }
 
-  return await Promise.all(
+  return Promise.all(
     Object.values(WORKLOAD_KIND_TO_TYPE_MAPPING).map((workloadType) =>
       store.dispatch(`cluster/findAll`, { type: workloadType })
     )
@@ -231,7 +231,7 @@ async function fetchPageSecondaryResources({ force, page }: { force: any; page: 
     return;
   }
 
-  return await Promise.all(
+  return Promise.all(
     Object.values(WORKLOAD_KIND_TO_TYPE_MAPPING).map((workloadType) =>
       store.dispatch(`cluster/findAll`, { type: workloadType })
     )

--- a/pkg/runtime-enforcer/list/security.rancher.io.workloadpolicy.vue
+++ b/pkg/runtime-enforcer/list/security.rancher.io.workloadpolicy.vue
@@ -8,10 +8,11 @@ import { DOCUMENTATION_URL, RESOURCE, type WorkloadPolicy } from '@runtime-enfor
 import { getActivePoliciesHeaders } from '@runtime-enforcer/config/policy-proposals-table';
 import RcButton from '@components/RcButton/RcButton.vue';
 import _ from 'lodash';
-import { PaginationFilterField, PaginationParamFilter } from '@shell/types/store/pagination.types';
 import { WORKLOAD_KINDS } from '@shell/config/types';
 import RichTranslation from '@shell/components/RichTranslation.vue';
 import SubtleLink from '@shell/components/SubtleLink.vue';
+import { WORKLOAD_KIND_TO_TYPE_MAPPING } from '@shell/config/types';
+import { FilterArgs, PaginationFilterField, PaginationParamFilter } from '@shell/types/store/pagination.types';
 
 const store = useStore();
 
@@ -27,7 +28,7 @@ function getAnyFilterOption() {
     label: t('runtimeEnforcer.activePolicies.filters.any')
   };
 }
-
+a
 const filters = ref({
   policySearch:   '',
   workloadSearch: '',
@@ -212,6 +213,30 @@ function changeModeSelected() {
     modalWidth: '640',
   });
 };
+
+async function fetchSecondaryResources({ canPaginate }: { canPaginate: boolean }) {
+  if (canPaginate) {
+    return;
+  }
+
+  return await Promise.all(
+    Object.values(WORKLOAD_KIND_TO_TYPE_MAPPING).map((workloadType) =>
+      store.dispatch(`cluster/findAll`, { type: workloadType })
+    )
+  );
+}
+
+async function fetchPageSecondaryResources({ force, page }: { force: any; page: any[] }) {
+  if (!page?.length) {
+    return;
+  }
+
+  return await Promise.all(
+    Object.values(WORKLOAD_KIND_TO_TYPE_MAPPING).map((workloadType) =>
+      store.dispatch(`cluster/findAll`, { type: workloadType })
+    )
+  );
+}
 </script>
 
 <template>
@@ -301,6 +326,8 @@ function changeModeSelected() {
       :key-field="'id'"
       :local-filter="filterRowsLocal"
       :api-filter="filterRowsApi"
+      :fetch-secondary-resources="fetchSecondaryResources"
+      :fetch-page-secondary-resources="fetchPageSecondaryResources"
       :use-query-params-for-simple-filtering="useQueryParamsForSimpleFiltering"
       @selection="onSelectionChange"
     >

--- a/pkg/runtime-enforcer/models/__tests__/security.rancher.io.workloadpolicyproposal.spec.ts
+++ b/pkg/runtime-enforcer/models/__tests__/security.rancher.io.workloadpolicyproposal.spec.ts
@@ -240,15 +240,12 @@ describe('WorkloadPolicyProposal model', () => {
         ]),
       };
 
-      const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
       const children = proposal.childrenRec;
 
       expect(children).toEqual([
         { container: 'web', image: 'nginx:1.25', executableCount: 1, executables: ['/usr/bin/nginx'] },
         { container: 'sidecar', image: 'busybox:1.36', executableCount: 2, executables: ['/usr/bin/agent', '/usr/bin/metrics'] },
       ]);
-      expect(logSpy).toHaveBeenCalledWith('image', expect.objectContaining({ web: 'nginx:1.25', sidecar: 'busybox:1.36' }), proposal.rulesByContainer);
-      logSpy.mockRestore();
     });
 
     it('uses job template containers when the workload is a job-based resource', () => {

--- a/pkg/runtime-enforcer/models/security.rancher.io.workloadpolicy.js
+++ b/pkg/runtime-enforcer/models/security.rancher.io.workloadpolicy.js
@@ -1,5 +1,5 @@
 import SteveModel from '@shell/plugins/steve/steve-class';
-import { RESOURCE, PROMOTE_LABEL_KEY } from '../types/runtime-enforcer';
+import { RESOURCE, POLICY_LABEL_KEY, PRODUCT_NAME } from '../types/runtime-enforcer';
 import { WORKLOAD_KIND_TO_TYPE_MAPPING } from '@shell/config/types';
 
 export default class WorkloadPolicyProposal extends SteveModel {
@@ -69,33 +69,45 @@ export default class WorkloadPolicyProposal extends SteveModel {
 
     return (() => {
       try {
-        Promise.all(
-          Object.values(WORKLOAD_KIND_TO_TYPE_MAPPING).map((workloadType) => {
-            const workloadList = this.$getters['all'](workloadType);
+        Object.values(WORKLOAD_KIND_TO_TYPE_MAPPING).map((workloadType) => {
+          const workloadList = this.$getters['all'](workloadType);
 
-            workloads = workloads.concat(workloadList || []);
-          })
-        );
+          workloads = workloads.concat(workloadList || []);
+        });
 
         const workload = workloads.find((workload) => {
-          return workload.metadata?.labels?.[PROMOTE_LABEL_KEY] === this.metadata?.name;
+          const podTemplate = workload.spec?.jobTemplate?.spec?.template ?? workload.spec?.template;
+
+          if (!podTemplate) {
+            return;
+          }
+
+          const metadata = podTemplate.metadata ??= {};
+          const labels = metadata.labels ??= {};
+
+          return labels?.[POLICY_LABEL_KEY] === this.metadata?.name && this.metadata?.namespace === workload.metadata?.namespace;
         });
 
         if (workload) {
+          const cluster = this.$rootState.targetRoute.params.cluster;
+
           return {
-            workloadName: workload.metadata?.name || '',
-            workloadType: workload.kind || '',
+            workloadName:     workload.metadata?.name || '',
+            workloadType:     workload.kind || '',
+            workloadLocation: `/c/${ cluster }/${ PRODUCT_NAME }/${ WORKLOAD_KIND_TO_TYPE_MAPPING[workload.kind] || '' }/${ workload.metadata?.namespace || '' }/${ workload.metadata?.name || '' }`,
           };
         }
 
         return {
-          workloadName: '',
-          workloadType: '',
+          workloadName:     '',
+          workloadType:     '',
+          workloadLocation: '',
         };
       } catch {
         return {
-          workloadName: '',
-          workloadType: '',
+          workloadName:     '',
+          workloadType:     '',
+          workloadLocation: '',
         };
       }
     })();
@@ -123,6 +135,7 @@ export default class WorkloadPolicyProposal extends SteveModel {
 
     Object.values(rulesByContainer).forEach((container) => {
       const allowedExecutables = container?.executables?.allowed || [];
+
       executables.push(...allowedExecutables);
     });
 
@@ -159,4 +172,3 @@ export default class WorkloadPolicyProposal extends SteveModel {
     });
   }
 }
-

--- a/pkg/runtime-enforcer/models/security.rancher.io.workloadpolicy.js
+++ b/pkg/runtime-enforcer/models/security.rancher.io.workloadpolicy.js
@@ -1,5 +1,6 @@
 import SteveModel from '@shell/plugins/steve/steve-class';
-import { RESOURCE } from '../types/runtime-enforcer';
+import { RESOURCE, PROMOTE_LABEL_KEY } from '../types/runtime-enforcer';
+import { WORKLOAD_KIND_TO_TYPE_MAPPING } from '@shell/config/types';
 
 export default class WorkloadPolicyProposal extends SteveModel {
   get _availableActions() {
@@ -61,6 +62,43 @@ export default class WorkloadPolicyProposal extends SteveModel {
     });
 
     return out;
+  }
+
+  get workloadRef() {
+    let workloads = [];
+
+    return (() => {
+      try {
+        Promise.all(
+          Object.values(WORKLOAD_KIND_TO_TYPE_MAPPING).map((workloadType) => {
+            const workloadList = this.$getters['all'](workloadType);
+
+            workloads = workloads.concat(workloadList || []);
+          })
+        );
+
+        const workload = workloads.find((workload) => {
+          return workload.metadata?.labels?.[PROMOTE_LABEL_KEY] === this.metadata?.name;
+        });
+
+        if (workload) {
+          return {
+            workloadName: workload.metadata?.name || '',
+            workloadType: workload.kind || '',
+          };
+        }
+
+        return {
+          workloadName: '',
+          workloadType: '',
+        };
+      } catch {
+        return {
+          workloadName: '',
+          workloadType: '',
+        };
+      }
+    })();
   }
 
   get violationCount() {

--- a/pkg/runtime-enforcer/models/security.rancher.io.workloadpolicyproposal.js
+++ b/pkg/runtime-enforcer/models/security.rancher.io.workloadpolicyproposal.js
@@ -148,8 +148,6 @@ export default class WorkloadPolicyProposal extends SteveModel {
           return acc;
         }, {});
 
-        console.log('image', image, this.rulesByContainer);
-
         return Object.entries(this.rulesByContainer).map(([containerName, containerRules]) => {
           return {
             container:       containerName,


### PR DESCRIPTION


## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

Fix #685 

Leverage fetching secondary resource interface in PaginatedResourceTable to get workload data from all types of workload resources. In the Steve model, use policy name to filter all the workload data to locate the workload by using lable key `security.rancher.io/promote`

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pull request -->

Go to Active policy pages to  observe workload and workload type fields.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
