### PR TITLE
update app token action input and handle missing secrets

### DIFF
--- a/.github/workflows/add_issue.yaml
+++ b/.github/workflows/add_issue.yaml
@@ -12,8 +12,11 @@ jobs:
     steps:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
+        env:
+          APP_ID: ${{ secrets.ADD_ISSUE_APP_ID }}
+        if: env.APP_ID != ''
         with:
-          app-id: ${{ secrets.ADD_ISSUE_APP_ID }}
+          client-id: ${{ secrets.ADD_ISSUE_APP_ID }}
           private-key: ${{ secrets.ADD_ISSUE_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           permission-organization-projects: write

--- a/.github/workflows/add_issue.yaml
+++ b/.github/workflows/add_issue.yaml
@@ -14,13 +14,15 @@ jobs:
         id: app-token
         env:
           APP_ID: ${{ secrets.ADD_ISSUE_APP_ID }}
-        if: env.APP_ID != ''
+          PRIVATE_KEY: ${{ secrets.ADD_ISSUE_PRIVATE_KEY }}
+        if: env.APP_ID != '' && env.PRIVATE_KEY != ''
         with:
           client-id: ${{ secrets.ADD_ISSUE_APP_ID }}
           private-key: ${{ secrets.ADD_ISSUE_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           permission-organization-projects: write
       - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
+        if: steps.app-token.outcome == 'success'
         with:
           project-url: https://github.com/orgs/rancher/projects/143
           github-token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
- Replace deprecated 'app-id' with 'client-id' in actions/create-github-app-token
- Pass secret via env context with conditional check to safely handle PR runs where secrets are unavailable

https://github.com/rancher/security-ui-exts/actions/runs/31623978573

<img width="1633" height="891" alt="Screenshot 2026-08-12 at 11 18 58 AM" src="https://github.com/user-attachments/assets/0e9ff027-f056-4a1c-b8f7-5bf4abc4f4b6" />


