### PR TITLE
Runtime Enforcer: Align growl titles & workload copy-to-clipboard UX 

### DIFF
--- a/pkg/runtime-enforcer/components/common/WorkloadTag.vue
+++ b/pkg/runtime-enforcer/components/common/WorkloadTag.vue
@@ -1,0 +1,80 @@
+<template>
+  <div class="workload-row">
+    <RcTag
+      class="tag-row"
+      :highlight="false"
+    >
+      <div class="tag-data">{{ label }}</div>
+    </RcTag>
+    <CopyToClipboard
+      class="cp-board"
+      :value="label"
+    />
+  </div>
+</template>
+
+<script>
+import RcTag from '@components/Pill/RcTag/RcTag.vue';
+import CopyToClipboard from '@shell/components/Resource/Detail/CopyToClipboard.vue';
+
+export default {
+  name: 'WorkloadTag',
+
+  components: { RcTag, CopyToClipboard },
+
+  props: {
+    label: {
+      type:     String,
+      required: true,
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.workload-row {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  margin: 6px 0;
+}
+
+.tag-row {
+  display: inline-flex;
+  align-items: center;
+  background-color: var(--rc-active-disabled-background);
+  border: 1px solid var(--rc-active-disabled-background);
+  border-radius: 4px;
+}
+
+.tag-data {
+  display: inline-flex;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: calc(100%);
+  line-height: 21px;
+  font-size: 13px;
+  font-weight: 400;
+  align-items: center;
+}
+
+.cp-board {
+  position: fixed;
+  top: -100vh;
+  right: -8px;
+}
+
+.workload-row:hover .cp-board,
+.workload-row:focus-within .cp-board,
+.cp-board:hover,
+.cp-board:focus-visible {
+  position: absolute;
+  top: -6px;
+}
+
+.workload-row:hover .tag-data,
+.workload-row:focus-within .tag-data {
+  padding-right: 22px;
+}
+</style>

--- a/pkg/runtime-enforcer/components/common/__tests__/WorkloadTag.spec.ts
+++ b/pkg/runtime-enforcer/components/common/__tests__/WorkloadTag.spec.ts
@@ -1,0 +1,24 @@
+import { mount } from '@vue/test-utils';
+
+jest.mock('@shell/components/Resource/Detail/CopyToClipboard.vue', () => ({
+  __esModule: true,
+  default:    {
+    name: 'CopyToClipboard', props: ['value'], template: '<button class="cp-board" />'
+  },
+}));
+
+import WorkloadTag from '../WorkloadTag.vue';
+
+describe('WorkloadTag.vue', () => {
+  it('renders the label text in the tag', () => {
+    const wrapper = mount(WorkloadTag, { props: { label: 'security.rancher.io/policy : policy-a' } });
+
+    expect(wrapper.find('.tag-data').text()).toBe('security.rancher.io/policy : policy-a');
+  });
+
+  it('passes the label as the value to copy', () => {
+    const wrapper = mount(WorkloadTag, { props: { label: 'security.rancher.io/policy : policy-a' } });
+
+    expect(wrapper.findComponent({ name: 'CopyToClipboard' }).props('value')).toBe('security.rancher.io/policy : policy-a');
+  });
+});

--- a/pkg/runtime-enforcer/dialog/DeleteActivePoliciesDialog.vue
+++ b/pkg/runtime-enforcer/dialog/DeleteActivePoliciesDialog.vue
@@ -8,10 +8,9 @@ import { TIMESTAMP } from '@shell/config/labels-annotations';
 import RadioButton from '@components/Form/Radio/RadioButton.vue';
 import { _EDIT } from '@shell/config/query-params';
 import { DOCUMENTATION_URL, WORKLOAD_PREFIX, POLICY_LABEL_KEY } from '@runtime-enforcer/types';
-import RcTag from '@components/Pill/RcTag/RcTag.vue';
-import CopyToClipboard from '@shell/components/Resource/Detail/CopyToClipboard.vue';
 import RichTranslation from '@shell/components/RichTranslation.vue';
 import SubtleLink from '@shell/components/SubtleLink.vue';
+import WorkloadTag from '@runtime-enforcer/components/common/WorkloadTag.vue';
 import { WORKLOAD_KIND_TO_TYPE_MAPPING } from '@shell/config/types';
 
 export default {
@@ -22,10 +21,9 @@ export default {
     Banner,
     RcButton,
     RadioButton,
-    RcTag,
-    CopyToClipboard,
     RichTranslation,
     SubtleLink,
+    WorkloadTag,
   },
 
   props: {
@@ -284,19 +282,12 @@ export default {
                     </template>
                   </RichTranslation>
                 </p>
-                <div
-                  v-for="resource in resources"
-                  :key="resource.metadata.uid"
-                  class="mt-2"
-                >
-                  <RcTag
-                    class="tag-row"
-                    :highlight="false"
-                  >
-                    <div class="tag-data">{{ WORKLOAD_PREFIX }} {{ resource.metadata.name }}</div>
-                  </RcTag>
-                  <CopyToClipboard class="cp-board" :value="`${ WORKLOAD_PREFIX } ${ resource.metadata.name }`" />
-                </div>
+                  <WorkloadTag
+                    v-for="resource in resources"
+                    :key="resource.metadata.uid"
+                    class="mt-2"
+                    :label="`${ WORKLOAD_PREFIX } ${ resource.metadata.name }`"
+                  />
               </template>
             </template>
           </RadioButton>
@@ -368,32 +359,6 @@ export default {
     .option-tooltip-icon {
       margin-left: 8px;
     }
-  }
-
-  .cp-board {
-    margin-left: -8px;
-    right: 0;
-    top: 0;
-  }
-  .tag-row {
-    display: inline-flex;
-    align-items: center;
-    background-color: var(--rc-active-disabled-background);
-    border: 1px solid var(--rc-active-disabled-background);
-    border-radius: 4px;
-    margin: 6px 0;
-    cursor: default;
-  }
-  .tag-data {
-    display: inline-flex;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    max-width: calc(100%);
-    line-height: 21px;
-    font-size: 13px;
-    font-weight: 400;
-    align-items: center;
   }
 }
 </style>

--- a/pkg/runtime-enforcer/dialog/DeleteActivePoliciesDialog.vue
+++ b/pkg/runtime-enforcer/dialog/DeleteActivePoliciesDialog.vue
@@ -112,8 +112,8 @@ export default {
     },
     growlTitle() {
       return this.isBulk
-        ? this.t('runtimeEnforcer.activePolicies.deleteDialog.growl.title.bulk', { count: this.resources.length }, true)
-        : this.t('runtimeEnforcer.activePolicies.deleteDialog.growl.title.single', { name: this.resources[0]?.nameDisplay }, true);
+        ? this.t('runtimeEnforcer.activePolicies.deleteDialog.growl.title.bulk')
+        : this.t('runtimeEnforcer.activePolicies.deleteDialog.growl.title.single');
     },
   },
 

--- a/pkg/runtime-enforcer/dialog/DeletePolicyProposalsDialog.vue
+++ b/pkg/runtime-enforcer/dialog/DeletePolicyProposalsDialog.vue
@@ -68,8 +68,8 @@ export default {
 
     growlTitle() {
       return this.isBulk
-        ? this.t('runtimeEnforcer.policyProposal.deleteDialog.growl.title.bulk', { count: this.resources.length }, true)
-        : this.t('runtimeEnforcer.policyProposal.deleteDialog.growl.title.single', { name: this.resources[0]?.nameDisplay }, true);
+        ? this.t('runtimeEnforcer.policyProposal.deleteDialog.growl.title.bulk')
+        : this.t('runtimeEnforcer.policyProposal.deleteDialog.growl.title.single');
     },
   },
 

--- a/pkg/runtime-enforcer/dialog/PromotePolicyDialog.vue
+++ b/pkg/runtime-enforcer/dialog/PromotePolicyDialog.vue
@@ -4,10 +4,9 @@ import { Banner } from '@components/Banner';
 import RcButton from '@components/RcButton/RcButton.vue';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 import RadioButton from '@components/Form/Radio/RadioButton.vue';
-import RcTag from '@components/Pill/RcTag/RcTag.vue';
-import CopyToClipboard from '@shell/components/Resource/Detail/CopyToClipboard.vue';
 import RichTranslation from '@shell/components/RichTranslation.vue';
 import SubtleLink from '@shell/components/SubtleLink.vue';
+import WorkloadTag from '@runtime-enforcer/components/common/WorkloadTag.vue';
 import { _EDIT } from '@shell/config/query-params';
 import {
   PRODUCT_NAME, POLICY_MODE, APPLY_MODE, WORKLOAD_PREFIX, DOCUMENTATION_URL
@@ -23,10 +22,9 @@ export default {
     RcButton,
     LabeledSelect,
     RadioButton,
-    RcTag,
-    CopyToClipboard,
     RichTranslation,
     SubtleLink,
+    WorkloadTag,
   },
 
   props: {
@@ -242,19 +240,12 @@ export default {
                       </template>
                     </RichTranslation>
                   </p>
-                  <div
+                  <WorkloadTag
                     v-for="resource in resources"
                     :key="resource.metadata.uid"
                     class="mt-2"
-                  >
-                    <RcTag
-                      class="tag-row"
-                      :highlight="false"
-                    >
-                      <div class="tag-data">{{ WORKLOAD_PREFIX }} {{ resource.metadata.name }}</div>
-                    </RcTag>
-                    <CopyToClipboard class="cp-board" :value="`${ WORKLOAD_PREFIX } ${ resource.metadata.name }`" />
-                  </div>
+                    :label="`${ WORKLOAD_PREFIX } ${ resource.metadata.name }`"
+                  />
                 </template>
               </template>
             </RadioButton>
@@ -334,29 +325,5 @@ export default {
     }
   }
 
-  .tag-row {
-    display: inline-flex;
-    align-items: center;
-    background-color: var(--rc-active-disabled-background);
-    border: 1px solid var(--rc-active-disabled-background);
-    border-radius: 4px;
-    margin: 6px 0;
-  }
-
-  .cp-board {
-    margin-left: -4px;
-  }
-
-  .tag-data {
-    display: inline-flex;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    max-width: calc(100%);
-    line-height: 21px;
-    font-size: 13px;
-    font-weight: 400;
-    align-items: center;
-  }
 }
 </style>

--- a/pkg/runtime-enforcer/dialog/PromotePolicyDialog.vue
+++ b/pkg/runtime-enforcer/dialog/PromotePolicyDialog.vue
@@ -93,14 +93,14 @@ export default {
 
     growlTitle() {
       return this.isBulk
-        ? this.t('runtimeEnforcer.policyProposal.promoteDialog.growl.title.bulk', { count: this.resources.length }, true)
-        : this.t('runtimeEnforcer.policyProposal.promoteDialog.growl.title.single', { name: this.resources[0]?.nameDisplay }, true);
+        ? this.t('runtimeEnforcer.policyProposal.promoteDialog.growl.title.bulk')
+        : this.t('runtimeEnforcer.policyProposal.promoteDialog.growl.title.single');
     },
 
     growlMessage() {
       const base = this.isBulk
         ? this.t('runtimeEnforcer.policyProposal.promoteDialog.growl.base.bulk', { count: this.resources.length }, true)
-        : this.t('runtimeEnforcer.policyProposal.promoteDialog.growl.base.single', {}, true);
+        : this.t('runtimeEnforcer.policyProposal.promoteDialog.growl.base.single', { name: this.resources[0]?.nameDisplay }, true);
 
       const suffixKey = this.applyOption === APPLY_MODE.AUTOMATIC ? 'automatic' : 'manual';
       const suffix = this.t(`runtimeEnforcer.policyProposal.promoteDialog.growl.${ suffixKey }.${ this.isBulk ? 'bulk' : 'single' }`, {}, true);

--- a/pkg/runtime-enforcer/dialog/__tests__/DeleteActivePoliciesDialog.spec.ts
+++ b/pkg/runtime-enforcer/dialog/__tests__/DeleteActivePoliciesDialog.spec.ts
@@ -207,19 +207,19 @@ describe('DeleteActivePoliciesDialog', () => {
   });
 
   describe('computed: growlTitle', () => {
-    it('returns single growl title with name', () => {
+    it('returns single growl title', () => {
       const { wrapper } = mountDialog({ resources: [createResource('nginx-policy', 'nginx')] });
 
       expect((wrapper.vm as any).growlTitle).toBe(
-        'runtimeEnforcer.activePolicies.deleteDialog.growl.title.single:{"name":"nginx-policy"}'
+        'runtimeEnforcer.activePolicies.deleteDialog.growl.title.single'
       );
     });
 
-    it('returns bulk growl title with count', () => {
+    it('returns bulk growl title', () => {
       const { wrapper } = mountDialog({ resources: [createResource('a'), createResource('b')] });
 
       expect((wrapper.vm as any).growlTitle).toBe(
-        'runtimeEnforcer.activePolicies.deleteDialog.growl.title.bulk:{"count":2}'
+        'runtimeEnforcer.activePolicies.deleteDialog.growl.title.bulk'
       );
     });
   });
@@ -278,7 +278,7 @@ describe('DeleteActivePoliciesDialog', () => {
       expect(resources[1].remove).toHaveBeenCalledTimes(1);
       expect(redeploySpy).not.toHaveBeenCalled();
       expect(dispatch).toHaveBeenCalledWith('growl/success', {
-        title:   'runtimeEnforcer.activePolicies.deleteDialog.growl.title.bulk:{"count":2}',
+        title:   'runtimeEnforcer.activePolicies.deleteDialog.growl.title.bulk',
         message: 'runtimeEnforcer.activePolicies.deleteDialog.growl.delete.bulk',
       });
       expect(push).toHaveBeenCalledWith({
@@ -302,7 +302,7 @@ describe('DeleteActivePoliciesDialog', () => {
       expect(resources[1].remove).toHaveBeenCalledTimes(1);
       expect(redeploySpy).toHaveBeenCalledTimes(2);
       expect(dispatch).toHaveBeenCalledWith('growl/success', {
-        title:   'runtimeEnforcer.activePolicies.deleteDialog.growl.title.bulk:{"count":2}',
+        title:   'runtimeEnforcer.activePolicies.deleteDialog.growl.title.bulk',
         message: 'runtimeEnforcer.activePolicies.deleteDialog.growl.delete.bulk runtimeEnforcer.activePolicies.deleteDialog.growl.autoRemoval.bulk',
       });
       expect((wrapper.vm as any).deleteInProgress).toBe(false);
@@ -320,7 +320,7 @@ describe('DeleteActivePoliciesDialog', () => {
 
       expect(redeploySpy).not.toHaveBeenCalled();
       expect(dispatch).toHaveBeenCalledWith('growl/success', {
-        title:   'runtimeEnforcer.activePolicies.deleteDialog.growl.title.single:{"name":"a"}',
+        title:   'runtimeEnforcer.activePolicies.deleteDialog.growl.title.single',
         message: 'runtimeEnforcer.activePolicies.deleteDialog.growl.delete.single runtimeEnforcer.activePolicies.deleteDialog.growl.manualRemoval.single',
       });
       expect((wrapper.vm as any).deleteInProgress).toBe(false);

--- a/pkg/runtime-enforcer/dialog/__tests__/DeletePolicyProposalsDialog.spec.ts
+++ b/pkg/runtime-enforcer/dialog/__tests__/DeletePolicyProposalsDialog.spec.ts
@@ -57,7 +57,7 @@ describe('DeletePolicyProposalsDialog', () => {
       );
       expect((wrapper.vm as any).growlMessage).toBe('runtimeEnforcer.policyProposal.deleteDialog.growl.single');
       expect((wrapper.vm as any).growlTitle).toBe(
-        'runtimeEnforcer.policyProposal.deleteDialog.growl.title.single:{"name":"single-policy"}'
+        'runtimeEnforcer.policyProposal.deleteDialog.growl.title.single'
       );
     });
 
@@ -75,7 +75,7 @@ describe('DeletePolicyProposalsDialog', () => {
       );
       expect((wrapper.vm as any).growlMessage).toBe('runtimeEnforcer.policyProposal.deleteDialog.growl.bulk');
       expect((wrapper.vm as any).growlTitle).toBe(
-        'runtimeEnforcer.policyProposal.deleteDialog.growl.title.bulk:{"count":2}'
+        'runtimeEnforcer.policyProposal.deleteDialog.growl.title.bulk'
       );
     });
   });
@@ -154,7 +154,7 @@ describe('DeletePolicyProposalsDialog', () => {
       expect(redeploySpy).toHaveBeenNthCalledWith(2, resources[1]);
       expect((wrapper.vm as any).deleteInProgress).toBe(false);
       expect(dispatch).toHaveBeenCalledWith('growl/success', {
-        title:   'runtimeEnforcer.policyProposal.deleteDialog.growl.title.bulk:{"count":2}',
+        title:   'runtimeEnforcer.policyProposal.deleteDialog.growl.title.bulk',
         message: 'runtimeEnforcer.policyProposal.deleteDialog.growl.bulk',
       });
       expect(push).toHaveBeenCalledWith({

--- a/pkg/runtime-enforcer/dialog/__tests__/PromotePolicyDialog.spec.ts
+++ b/pkg/runtime-enforcer/dialog/__tests__/PromotePolicyDialog.spec.ts
@@ -110,10 +110,10 @@ describe('PromotePolicyDialog', () => {
 
       (wrapper.vm as any).applyOption = APPLY_MODE.AUTOMATIC;
       expect((wrapper.vm as any).growlTitle).toBe(
-        'runtimeEnforcer.policyProposal.promoteDialog.growl.title.single {"name":"proposal-a"}'
+        'runtimeEnforcer.policyProposal.promoteDialog.growl.title.single'
       );
       expect((wrapper.vm as any).growlMessage).toBe(
-        'runtimeEnforcer.policyProposal.promoteDialog.growl.base.single {} runtimeEnforcer.policyProposal.promoteDialog.growl.automatic.single {}'
+        'runtimeEnforcer.policyProposal.promoteDialog.growl.base.single {"name":"proposal-a"} runtimeEnforcer.policyProposal.promoteDialog.growl.automatic.single {}'
       );
     });
 
@@ -122,7 +122,7 @@ describe('PromotePolicyDialog', () => {
 
       (wrapper.vm as any).applyOption = APPLY_MODE.MANUAL;
       expect((wrapper.vm as any).growlTitle).toBe(
-        'runtimeEnforcer.policyProposal.promoteDialog.growl.title.bulk {"count":2}'
+        'runtimeEnforcer.policyProposal.promoteDialog.growl.title.bulk'
       );
       expect((wrapper.vm as any).growlMessage).toBe(
         'runtimeEnforcer.policyProposal.promoteDialog.growl.base.bulk {"count":2} runtimeEnforcer.policyProposal.promoteDialog.growl.manual.bulk {}'

--- a/pkg/runtime-enforcer/l10n/en-us.yaml
+++ b/pkg/runtime-enforcer/l10n/en-us.yaml
@@ -153,9 +153,9 @@ runtimeEnforcer:
         bulk: Restart Workloads
       growl:
         title:
-          single: '{name} has been deleted'
-          bulk: Selected policy proposals ({count}) have been deleted
-        single: The policy proposal {name} has been successfully deleted. Restarting the corresponding workload might take a few minutes to complete.
+          single: Policy Proposal Deleted
+          bulk: Policy Proposals Deleted
+        single: The {name} policy proposal has been successfully deleted. Restarting the corresponding workload might take a few minutes to complete.
         bulk: The selected policy proposals ({count}) have been successfully deleted. Restarting the corresponding workloads might take a few minutes to complete.
     promoteDialog:
       title:
@@ -195,10 +195,10 @@ runtimeEnforcer:
       errorTitle: Failed to promote policy proposal
       growl:
         title:
-          single: '{name} has been promoted to active policy'
-          bulk: Selected policy proposals ({count}) have been promoted to active policies
+          single: Policy Proposal Promoted
+          bulk: Policy Proposals Promoted
         base:
-          single: The policy proposal has been successfully promoted to an active policy.
+          single: The {name} policy proposal has been successfully promoted to an active policy.
           bulk: The selected policy proposals ({count}) have been successfully promoted to active policies.
         manual:
           single: Don't forget to manually apply the active policy on the corresponding workload and redeploy it.
@@ -309,8 +309,8 @@ runtimeEnforcer:
         bulk: Restart Workloads
       growl:
         title:
-          single: '{name} has been deleted'
-          bulk: Selected active policies ({count}) have been deleted
+          single: Active Policy Deleted
+          bulk: Active Policies Deleted
         delete:
           single: The {name} active policy has been successfully deleted.
           bulk: The selected active policies ({count}) have been successfully deleted.


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

Fix #683

Addresses two UX review items:
- Growl notification titles for the Promote/Delete Policy Proposal and Delete Active Policy dialogs are now short and generic (e.g. "Policy Proposal Deleted"), with the detailed, explicit copy moved into the growl message body
- The workload copy-to-clipboard icon in the Promote/Delete Active Policy dialogs now only appears on hover/focus of the workload tag, instead of always being visible — extracted into a shared `WorkloadTag` component.

## Test

1. Trigger a Promote Policy Proposal (single and bulk) and confirm the growl title is short/generic and the message includes the proposal name(s).
2. Trigger a Delete Policy Proposal (single and bulk) and a Delete Active Policy, and confirm the same growl title/message pattern.
3. Open the Promote Policy dialog or Delete Active Policies dialog, and hover/keyboard-focus over a workload tag — confirm the copy-to-clipboard icon only appears then, doesn't overlap the tag text, and still copies the correct value.

## Additional Information

### Tradeoff

The copy-to-clipboard reveal uses `position: fixed / absolute` off-screen toggling plus a `padding-right` ellipsis adjustment (matching `@shell/components/Resource/Detail/Metadata/KeyValueRow.vue`'s existing pattern) rather than a simpler `opacity / visibility` toggle, so the button remains keyboard-focusable. We opted not to reuse `KeyValueRow.vue` directly since it bundles an unwanted click-to-preview modal and a different data shape/styling.

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
